### PR TITLE
feat: rich ecommerce admin UI elements + drill-through navigation

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -926,6 +926,114 @@ table.j-table tbody tr:hover td { background: rgba(24, 21, 18, 0.025); }
 }
 
 /* ══════════════════════════════════════════════════════════════════════════
+   STAT BAR — horizontal row of headline numbers
+   ══════════════════════════════════════════════════════════════════════════ */
+.j-stat-bar { display: flex; border: 1px solid var(--border-card); border-radius: 4px; overflow: hidden; }
+.j-stat-bar-item { flex: 1; padding: 18px 22px; border-right: 1px solid var(--border-card); background: var(--card-bg); }
+.j-stat-bar-item:last-child { border-right: none; }
+.j-stat-bar-value { font-family: "Noto Serif Display", Georgia, serif; font-size: 1.55rem; font-weight: 600; color: var(--text-primary); line-height: 1; margin-bottom: 5px; }
+.j-stat-bar-label { font-family: "Montserrat", sans-serif; font-size: 9px; font-weight: 700; letter-spacing: 0.2em; text-transform: uppercase; color: rgba(24,21,18,0.38); }
+.j-stat-bar-delta { font-family: "Manrope", sans-serif; font-size: 0.75rem; margin-top: 4px; }
+
+/* ══════════════════════════════════════════════════════════════════════════
+   BREADCRUMB
+   ══════════════════════════════════════════════════════════════════════════ */
+.j-breadcrumb { display: flex; align-items: center; gap: 8px; font-family: "Montserrat", sans-serif; font-size: 10px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase; color: rgba(24,21,18,0.38); margin-bottom: 24px; flex-wrap: wrap; }
+.j-breadcrumb-link { cursor: pointer; background: none; border: none; padding: 0; font: inherit; letter-spacing: inherit; color: inherit; transition: color 130ms ease; }
+.j-breadcrumb-link:hover { color: var(--text-primary); }
+.j-breadcrumb-sep { opacity: 0.35; }
+.j-breadcrumb-current { color: var(--text-primary); }
+
+/* ══════════════════════════════════════════════════════════════════════════
+   SECTION HEADER
+   ══════════════════════════════════════════════════════════════════════════ */
+.j-section-header { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 14px; gap: 12px; }
+.j-section-title { font-family: "Noto Serif Display", Georgia, serif; font-size: 1.05rem; font-weight: 600; color: var(--text-primary); }
+
+/* ══════════════════════════════════════════════════════════════════════════
+   ACTION BAR
+   ══════════════════════════════════════════════════════════════════════════ */
+.j-action-bar { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; padding: 16px 0; border-top: 1px solid var(--border-divider); margin-top: 24px; }
+
+/* Back button */
+.j-back-btn { display: inline-flex; align-items: center; gap: 6px; font-family: "Montserrat", sans-serif; font-size: 10px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase; color: rgba(24,21,18,0.42); background: none; border: none; cursor: pointer; padding: 0; margin-bottom: 20px; transition: color 130ms ease; }
+.j-back-btn:hover { color: var(--text-primary); }
+.j-back-btn-arrow { font-size: 14px; }
+
+/* ══════════════════════════════════════════════════════════════════════════
+   PRODUCT GRID
+   ══════════════════════════════════════════════════════════════════════════ */
+.j-product-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(190px, 1fr)); gap: 16px; }
+.j-product-card { background: var(--card-bg); border: 1px solid var(--border-card); border-radius: 4px; overflow: hidden; cursor: pointer; transition: box-shadow 180ms ease, transform 180ms ease; }
+.j-product-card:hover { box-shadow: 0 8px 28px rgba(0,0,0,0.09); transform: translateY(-1px); }
+.j-product-card-img { width: 100%; aspect-ratio: 1; background: #e8e2d9; display: flex; align-items: center; justify-content: center; font-family: "Montserrat", sans-serif; font-size: 11px; font-weight: 700; letter-spacing: 0.15em; color: rgba(24,21,18,0.18); text-transform: uppercase; }
+.j-product-card-body { padding: 14px; }
+.j-product-card-name { font-family: "Manrope", sans-serif; font-size: 0.85rem; font-weight: 600; color: var(--text-primary); margin-bottom: 6px; line-height: 1.3; }
+.j-product-card-price { font-family: "Noto Serif Display", Georgia, serif; font-size: 1rem; font-weight: 600; color: var(--text-primary); }
+.j-product-card-compare { font-family: "Manrope", sans-serif; font-size: 0.78rem; color: var(--text-faint); text-decoration: line-through; margin-left: 6px; }
+.j-product-card-stock { font-family: "Manrope", sans-serif; font-size: 0.75rem; color: var(--text-faint); margin-top: 4px; }
+
+/* ══════════════════════════════════════════════════════════════════════════
+   DETAIL LAYOUTS
+   ══════════════════════════════════════════════════════════════════════════ */
+.j-detail-grid { display: grid; grid-template-columns: 3fr 2fr; gap: 24px; align-items: start; }
+@media (max-width: 720px) { .j-detail-grid { grid-template-columns: 1fr; } }
+
+/* Line items */
+.j-line-items { width: 100%; border-collapse: collapse; }
+.j-line-items td { font-family: "Manrope", sans-serif; font-size: 0.875rem; color: var(--text-body); padding: 11px 0; border-bottom: 1px solid var(--border-divider); vertical-align: top; }
+.j-line-items tr:last-child td { border-bottom: none; }
+.j-li-name { font-weight: 600; color: var(--text-primary); display: block; }
+.j-li-variant { font-size: 0.78rem; color: var(--text-faint); }
+.j-li-qty { color: var(--text-muted); white-space: nowrap; padding: 11px 16px !important; }
+.j-li-total { text-align: right; font-family: "Noto Serif Display", Georgia, serif; font-size: 0.95rem; font-weight: 600; white-space: nowrap; }
+
+/* Order totals */
+.j-totals { width: 100%; border-collapse: collapse; margin-top: 8px; }
+.j-totals td { font-family: "Manrope", sans-serif; font-size: 0.85rem; color: var(--text-body); padding: 5px 0; }
+.j-totals td:last-child { text-align: right; }
+.j-totals tr.total td { font-family: "Noto Serif Display", Georgia, serif; font-size: 1rem; font-weight: 600; color: var(--text-primary); border-top: 1px solid var(--border-divider); padding-top: 10px; }
+
+/* Customer avatar */
+.j-avatar { width: 40px; height: 40px; border-radius: 50%; background: var(--text-primary); color: var(--ink); display: inline-flex; align-items: center; justify-content: center; font-family: "Montserrat", sans-serif; font-size: 13px; font-weight: 700; flex-shrink: 0; }
+.j-avatar-lg { width: 56px; height: 56px; font-size: 18px; }
+
+/* Key-value list */
+.j-kv-list { display: flex; flex-direction: column; gap: 10px; }
+.j-kv-row { display: flex; gap: 8px; font-family: "Manrope", sans-serif; font-size: 0.85rem; }
+.j-kv-key { color: var(--text-faint); min-width: 90px; flex-shrink: 0; }
+.j-kv-val { color: var(--text-primary); font-weight: 500; }
+
+/* ══════════════════════════════════════════════════════════════════════════
+   PROMOTION CARDS
+   ══════════════════════════════════════════════════════════════════════════ */
+.j-promo-list { display: flex; flex-direction: column; gap: 12px; }
+.j-promo-card { background: var(--card-bg); border: 1px solid var(--border-card); border-radius: 4px; padding: 18px 22px; display: flex; align-items: flex-start; justify-content: space-between; gap: 20px; }
+.j-promo-left {}
+.j-promo-code { font-family: "Montserrat", sans-serif; font-size: 16px; font-weight: 700; letter-spacing: 0.12em; color: var(--text-primary); margin-bottom: 3px; }
+.j-promo-desc { font-family: "Manrope", sans-serif; font-size: 0.85rem; color: var(--text-muted); }
+.j-promo-meta { font-family: "Manrope", sans-serif; font-size: 0.78rem; color: var(--text-faint); margin-top: 6px; }
+.j-promo-right { text-align: right; flex-shrink: 0; display: flex; flex-direction: column; align-items: flex-end; gap: 6px; }
+.j-promo-uses-value { font-family: "Noto Serif Display", Georgia, serif; font-size: 1.3rem; font-weight: 600; color: var(--text-primary); line-height: 1; }
+.j-promo-uses-label { font-family: "Montserrat", sans-serif; font-size: 9px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase; color: rgba(24,21,18,0.38); }
+
+/* ══════════════════════════════════════════════════════════════════════════
+   INVENTORY TABLE WITH STOCK BARS
+   ══════════════════════════════════════════════════════════════════════════ */
+.j-inv-bar-wrap { background: rgba(24,21,18,0.08); border-radius: 100px; height: 5px; width: 80px; }
+.j-inv-bar-fill { height: 100%; border-radius: 100px; }
+.j-inv-bar-fill.ok  { background: #3a6645; }
+.j-inv-bar-fill.low { background: #9a3f2a; }
+
+/* ══════════════════════════════════════════════════════════════════════════
+   KPI ROW
+   ══════════════════════════════════════════════════════════════════════════ */
+.j-kpi-row { display: flex; gap: 36px; flex-wrap: wrap; padding: 0 0 20px; border-bottom: 1px solid var(--border-divider); margin-bottom: 28px; }
+.j-kpi-label { font-family: "Montserrat", sans-serif; font-size: 9px; font-weight: 700; letter-spacing: 0.2em; text-transform: uppercase; color: rgba(24,21,18,0.38); margin-bottom: 4px; }
+.j-kpi-value { font-family: "Noto Serif Display", Georgia, serif; font-size: 1.25rem; font-weight: 600; color: var(--text-primary); }
+.j-kpi-sub { font-family: "Manrope", sans-serif; font-size: 0.75rem; color: var(--text-faint); margin-top: 2px; }
+
+/* ══════════════════════════════════════════════════════════════════════════
    DRAG GHOST (tab reorder)
    ══════════════════════════════════════════════════════════════════════════ */
 .j-tab-ghost { opacity: 0.25; }

--- a/lib/jarga_admin/mock_data.ex
+++ b/lib/jarga_admin/mock_data.ex
@@ -1,0 +1,679 @@
+defmodule JargaAdmin.MockData do
+  @moduledoc """
+  Rich mock data for the generative admin UI demo.
+  Mimics a real Jarga Commerce store — handmade/artisan goods.
+  """
+
+  # ── Products ──────────────────────────────────────────────────────────────
+
+  def products do
+    [
+      %{
+        "id" => "prod_001",
+        "name" => "Leather Journal A5",
+        "sku" => "LJ-A5-BRN",
+        "price" => "£34.99",
+        "price_raw" => 3499,
+        "compare_at" => nil,
+        "stock" => 40,
+        "reorder_at" => 10,
+        "status" => "published",
+        "description" =>
+          "Full-grain vegetable-tanned leather journal with 192 pages of 100gsm ivory paper. Closes with a leather strap and brass clasp. Each cover develops a unique patina with use.",
+        "weight" => "340g",
+        "tags" => ["stationery", "leather", "journal", "bestseller"],
+        "revenue_30d" => "£1,259.64",
+        "units_sold_30d" => 36,
+        "variants" => [
+          %{"name" => "Brown", "sku" => "LJ-A5-BRN", "stock" => 24},
+          %{"name" => "Tan", "sku" => "LJ-A5-TAN", "stock" => 12},
+          %{"name" => "Black", "sku" => "LJ-A5-BLK", "stock" => 4}
+        ]
+      },
+      %{
+        "id" => "prod_002",
+        "name" => "Canvas Tote Bag",
+        "sku" => "CTB-NAT-001",
+        "price" => "£24.99",
+        "price_raw" => 2499,
+        "compare_at" => "£34.99",
+        "stock" => 3,
+        "reorder_at" => 20,
+        "status" => "published",
+        "description" =>
+          "Heavy-duty 12oz natural canvas tote. Reinforced handles, internal zip pocket. Printed with water-based inks. Machine washable at 30°.",
+        "weight" => "280g",
+        "tags" => ["bags", "canvas", "sustainable", "low-stock"],
+        "revenue_30d" => "£374.85",
+        "units_sold_30d" => 15,
+        "variants" => [
+          %{"name" => "Natural", "sku" => "CTB-NAT-001", "stock" => 3}
+        ]
+      },
+      %{
+        "id" => "prod_003",
+        "name" => "Ceramic Mug — Slate",
+        "sku" => "MUG-SL-001",
+        "price" => "£18.00",
+        "price_raw" => 1800,
+        "compare_at" => nil,
+        "stock" => 120,
+        "reorder_at" => 30,
+        "status" => "published",
+        "description" =>
+          "Wheel-thrown stoneware mug with a slate grey glaze and matte exterior. 350ml capacity. Dishwasher safe. Each piece varies slightly — handmade in Sheffield.",
+        "weight" => "320g",
+        "tags" => ["ceramics", "kitchen", "handmade"],
+        "revenue_30d" => "£918.00",
+        "units_sold_30d" => 51,
+        "variants" => [
+          %{"name" => "Slate", "sku" => "MUG-SL-001", "stock" => 60},
+          %{"name" => "Chalk", "sku" => "MUG-CH-001", "stock" => 38},
+          %{"name" => "Terracotta", "sku" => "MUG-TC-001", "stock" => 22}
+        ]
+      },
+      %{
+        "id" => "prod_004",
+        "name" => "Oak Serving Board",
+        "sku" => "OSB-LRG-001",
+        "price" => "£42.00",
+        "price_raw" => 4200,
+        "compare_at" => nil,
+        "stock" => 2,
+        "reorder_at" => 8,
+        "status" => "published",
+        "description" =>
+          "Solid English oak serving board with juice groove. Oiled with food-safe linseed. 40cm × 25cm × 2cm. Ideal for cheese, charcuterie, or bread.",
+        "weight" => "890g",
+        "tags" => ["kitchen", "oak", "serving", "low-stock"],
+        "revenue_30d" => "£294.00",
+        "units_sold_30d" => 7,
+        "variants" => [
+          %{"name" => "Large (40cm)", "sku" => "OSB-LRG-001", "stock" => 2},
+          %{"name" => "Small (28cm)", "sku" => "OSB-SML-001", "stock" => 0}
+        ]
+      },
+      %{
+        "id" => "prod_005",
+        "name" => "Beeswax Candle Set",
+        "sku" => "BWC-SET-3",
+        "price" => "£28.00",
+        "price_raw" => 2800,
+        "compare_at" => nil,
+        "stock" => 0,
+        "reorder_at" => 15,
+        "status" => "draft",
+        "description" =>
+          "Set of three hand-poured beeswax pillar candles. Natural honey scent. Burns for 40+ hours each. Lead-free cotton wick. Wrapped in recycled kraft paper.",
+        "weight" => "620g",
+        "tags" => ["candles", "beeswax", "gift", "out-of-stock"],
+        "revenue_30d" => "£0.00",
+        "units_sold_30d" => 0,
+        "variants" => [
+          %{"name" => "Set of 3", "sku" => "BWC-SET-3", "stock" => 0}
+        ]
+      },
+      %{
+        "id" => "prod_006",
+        "name" => "Wool Throw — Natural",
+        "sku" => "WTH-NAT-001",
+        "price" => "£89.00",
+        "price_raw" => 8900,
+        "compare_at" => nil,
+        "stock" => 15,
+        "reorder_at" => 5,
+        "status" => "published",
+        "description" =>
+          "Undyed pure wool throw, woven in Wales. 150cm × 200cm. Machine washable on wool cycle. Each throw is individually numbered. Warm, heavy, and incredibly soft.",
+        "weight" => "1100g",
+        "tags" => ["textiles", "wool", "welsh", "premium"],
+        "revenue_30d" => "£1,335.00",
+        "units_sold_30d" => 15,
+        "variants" => [
+          %{"name" => "Natural", "sku" => "WTH-NAT-001", "stock" => 15}
+        ]
+      },
+      %{
+        "id" => "prod_007",
+        "name" => "Brass Pen Set",
+        "sku" => "BPS-3-001",
+        "price" => "£19.99",
+        "price_raw" => 1999,
+        "compare_at" => "£24.99",
+        "stock" => 67,
+        "reorder_at" => 20,
+        "status" => "published",
+        "description" =>
+          "Set of three brass-finish ballpoint pens with black ink refills. Weighted for comfortable writing. Gift-boxed. Refillable with standard Parker-style cartridges.",
+        "weight" => "180g",
+        "tags" => ["stationery", "brass", "pens", "gift"],
+        "revenue_30d" => "£659.67",
+        "units_sold_30d" => 33,
+        "variants" => [
+          %{"name" => "Set of 3", "sku" => "BPS-3-001", "stock" => 67}
+        ]
+      },
+      %{
+        "id" => "prod_008",
+        "name" => "Linen Notebook Cover",
+        "sku" => "LNC-A5-001",
+        "price" => "£22.00",
+        "price_raw" => 2200,
+        "compare_at" => nil,
+        "stock" => 8,
+        "reorder_at" => 12,
+        "status" => "published",
+        "description" =>
+          "Natural linen notebook cover, fits A5. Pen loop, card slot, and bookmark ribbon. Fits standard Leuchtturm1917 or Moleskine notebooks. Wipe clean.",
+        "weight" => "95g",
+        "tags" => ["stationery", "linen", "cover", "low-stock"],
+        "revenue_30d" => "£352.00",
+        "units_sold_30d" => 16,
+        "variants" => [
+          %{"name" => "Natural", "sku" => "LNC-A5-NAT", "stock" => 5},
+          %{"name" => "Sage", "sku" => "LNC-A5-SGE", "stock" => 3}
+        ]
+      }
+    ]
+  end
+
+  def product(id), do: Enum.find(products(), &(&1["id"] == id))
+
+  # ── Orders ────────────────────────────────────────────────────────────────
+
+  def orders do
+    [
+      %{
+        "id" => "#1042",
+        "ref" => "ord_1042",
+        "customer" => "Sarah Mitchell",
+        "customer_id" => "cust_001",
+        "email" => "sarah.mitchell@example.com",
+        "date" => "4 Mar 2026",
+        "status" => "pending",
+        "fulfillment" => "unfulfilled",
+        "payment" => "paid",
+        "subtotal" => "£77.98",
+        "shipping" => "£4.95",
+        "tax" => "£16.59",
+        "total" => "£89.00",
+        "items" => [
+          %{
+            "name" => "Leather Journal A5",
+            "variant" => "Brown",
+            "sku" => "LJ-A5-BRN",
+            "qty" => 1,
+            "price" => "£34.99"
+          },
+          %{
+            "name" => "Canvas Tote Bag",
+            "variant" => "Natural",
+            "sku" => "CTB-NAT-001",
+            "qty" => 1,
+            "price" => "£24.99"
+          },
+          %{
+            "name" => "Ceramic Mug — Slate",
+            "variant" => "Slate",
+            "sku" => "MUG-SL-001",
+            "qty" => 1,
+            "price" => "£18.00"
+          }
+        ],
+        "address" => "14 Elm Street, Bristol, BS1 4RQ",
+        "timeline" => [
+          %{"event" => "Order placed", "time" => "4 Mar 2026, 09:14"},
+          %{"event" => "Payment confirmed — Visa ending 4242", "time" => "4 Mar 2026, 09:14"},
+          %{"event" => "Awaiting fulfilment", "time" => "4 Mar 2026, 09:15"}
+        ]
+      },
+      %{
+        "id" => "#1041",
+        "ref" => "ord_1041",
+        "customer" => "James Cooper",
+        "customer_id" => "cust_002",
+        "email" => "james.cooper@example.com",
+        "date" => "3 Mar 2026",
+        "status" => "fulfilled",
+        "fulfillment" => "fulfilled",
+        "payment" => "paid",
+        "subtotal" => "£200.00",
+        "shipping" => "£0.00",
+        "tax" => "£34.50",
+        "total" => "£234.50",
+        "items" => [
+          %{
+            "name" => "Wool Throw — Natural",
+            "variant" => "Natural",
+            "sku" => "WTH-NAT-001",
+            "qty" => 1,
+            "price" => "£89.00"
+          },
+          %{
+            "name" => "Oak Serving Board",
+            "variant" => "Large (40cm)",
+            "sku" => "OSB-LRG-001",
+            "qty" => 2,
+            "price" => "£84.00"
+          },
+          %{
+            "name" => "Brass Pen Set",
+            "variant" => "Set of 3",
+            "sku" => "BPS-3-001",
+            "qty" => 1,
+            "price" => "£19.99"
+          }
+        ],
+        "address" => "7 Harbour View, Edinburgh, EH6 6JJ",
+        "timeline" => [
+          %{"event" => "Order placed", "time" => "3 Mar 2026, 14:02"},
+          %{
+            "event" => "Payment confirmed — Mastercard ending 1234",
+            "time" => "3 Mar 2026, 14:02"
+          },
+          %{"event" => "Order packed", "time" => "3 Mar 2026, 16:30"},
+          %{"event" => "Dispatched — Royal Mail Tracked 48", "time" => "3 Mar 2026, 17:45"},
+          %{"event" => "Delivered", "time" => "5 Mar 2026, 11:20"}
+        ]
+      },
+      %{
+        "id" => "#1040",
+        "ref" => "ord_1040",
+        "customer" => "Emma Walsh",
+        "customer_id" => "cust_003",
+        "email" => "emma.walsh@example.com",
+        "date" => "3 Mar 2026",
+        "status" => "pending",
+        "fulfillment" => "unfulfilled",
+        "payment" => "paid",
+        "subtotal" => "£37.50",
+        "shipping" => "£4.95",
+        "tax" => "£7.98",
+        "total" => "£45.00",
+        "items" => [
+          %{
+            "name" => "Ceramic Mug — Slate",
+            "variant" => "Chalk",
+            "sku" => "MUG-CH-001",
+            "qty" => 1,
+            "price" => "£18.00"
+          },
+          %{
+            "name" => "Linen Notebook Cover",
+            "variant" => "Sage",
+            "sku" => "LNC-A5-SGE",
+            "qty" => 1,
+            "price" => "£22.00"
+          }
+        ],
+        "address" => "22 Rose Lane, Oxford, OX1 3DP",
+        "timeline" => [
+          %{"event" => "Order placed", "time" => "3 Mar 2026, 11:33"},
+          %{"event" => "Payment confirmed — Visa ending 9012", "time" => "3 Mar 2026, 11:33"},
+          %{"event" => "Awaiting fulfilment", "time" => "3 Mar 2026, 11:34"}
+        ]
+      },
+      %{
+        "id" => "#1039",
+        "ref" => "ord_1039",
+        "customer" => "Oliver Park",
+        "customer_id" => "cust_004",
+        "email" => "o.park@example.com",
+        "date" => "2 Mar 2026",
+        "status" => "fulfilled",
+        "fulfillment" => "fulfilled",
+        "payment" => "paid",
+        "subtotal" => "£148.00",
+        "shipping" => "£0.00",
+        "tax" => "£29.60",
+        "total" => "£178.00",
+        "items" => [
+          %{
+            "name" => "Wool Throw — Natural",
+            "variant" => "Natural",
+            "sku" => "WTH-NAT-001",
+            "qty" => 1,
+            "price" => "£89.00"
+          },
+          %{
+            "name" => "Leather Journal A5",
+            "variant" => "Black",
+            "sku" => "LJ-A5-BLK",
+            "qty" => 1,
+            "price" => "£34.99"
+          },
+          %{
+            "name" => "Brass Pen Set",
+            "variant" => "Set of 3",
+            "sku" => "BPS-3-001",
+            "qty" => 1,
+            "price" => "£19.99"
+          }
+        ],
+        "address" => "9 King Street, Manchester, M2 4LQ",
+        "timeline" => [
+          %{"event" => "Order placed", "time" => "2 Mar 2026, 18:09"},
+          %{"event" => "Payment confirmed", "time" => "2 Mar 2026, 18:09"},
+          %{"event" => "Packed", "time" => "3 Mar 2026, 09:15"},
+          %{"event" => "Dispatched — DPD Next Day", "time" => "3 Mar 2026, 10:00"},
+          %{"event" => "Delivered", "time" => "4 Mar 2026, 09:42"}
+        ]
+      },
+      %{
+        "id" => "#1038",
+        "ref" => "ord_1038",
+        "customer" => "Lily Chen",
+        "customer_id" => "cust_005",
+        "email" => "lily.chen@example.com",
+        "date" => "2 Mar 2026",
+        "status" => "pending",
+        "fulfillment" => "unfulfilled",
+        "payment" => "paid",
+        "subtotal" => "£55.99",
+        "shipping" => "£4.95",
+        "tax" => "£11.00",
+        "total" => "£67.00",
+        "items" => [
+          %{
+            "name" => "Leather Journal A5",
+            "variant" => "Tan",
+            "sku" => "LJ-A5-TAN",
+            "qty" => 1,
+            "price" => "£34.99"
+          },
+          %{
+            "name" => "Brass Pen Set",
+            "variant" => "Set of 3",
+            "sku" => "BPS-3-001",
+            "qty" => 1,
+            "price" => "£19.99"
+          }
+        ],
+        "address" => "3 Canary Wharf, London, E14 5AB",
+        "timeline" => [
+          %{"event" => "Order placed", "time" => "2 Mar 2026, 08:22"},
+          %{"event" => "Payment confirmed — Amex ending 0005", "time" => "2 Mar 2026, 08:22"},
+          %{"event" => "Awaiting fulfilment", "time" => "2 Mar 2026, 08:23"}
+        ]
+      },
+      %{
+        "id" => "#1037",
+        "ref" => "ord_1037",
+        "customer" => "Tom Hassan",
+        "customer_id" => "cust_002",
+        "email" => "t.hassan@example.com",
+        "date" => "1 Mar 2026",
+        "status" => "refunded",
+        "fulfillment" => "fulfilled",
+        "payment" => "refunded",
+        "subtotal" => "£42.00",
+        "shipping" => "£4.95",
+        "tax" => "£9.39",
+        "total" => "£42.00",
+        "items" => [
+          %{
+            "name" => "Oak Serving Board",
+            "variant" => "Large (40cm)",
+            "sku" => "OSB-LRG-001",
+            "qty" => 1,
+            "price" => "£42.00"
+          }
+        ],
+        "address" => "18 Park Avenue, Leeds, LS1 3DL",
+        "timeline" => [
+          %{"event" => "Order placed", "time" => "1 Mar 2026, 13:00"},
+          %{"event" => "Payment confirmed", "time" => "1 Mar 2026, 13:00"},
+          %{"event" => "Dispatched", "time" => "2 Mar 2026, 10:30"},
+          %{"event" => "Delivered", "time" => "3 Mar 2026, 14:00"},
+          %{"event" => "Return requested — damaged in transit", "time" => "3 Mar 2026, 18:45"},
+          %{"event" => "Refund issued — £42.00", "time" => "4 Mar 2026, 09:00"}
+        ]
+      },
+      %{
+        "id" => "#1036",
+        "ref" => "ord_1036",
+        "customer" => "Priya Nair",
+        "customer_id" => "cust_006",
+        "email" => "priya.nair@example.com",
+        "date" => "28 Feb 2026",
+        "status" => "fulfilled",
+        "fulfillment" => "fulfilled",
+        "payment" => "paid",
+        "subtotal" => "£106.99",
+        "shipping" => "£0.00",
+        "tax" => "£21.40",
+        "total" => "£128.00",
+        "items" => [
+          %{
+            "name" => "Leather Journal A5",
+            "variant" => "Brown",
+            "sku" => "LJ-A5-BRN",
+            "qty" => 1,
+            "price" => "£34.99"
+          },
+          %{
+            "name" => "Ceramic Mug — Slate",
+            "variant" => "Terracotta",
+            "sku" => "MUG-TC-001",
+            "qty" => 2,
+            "price" => "£36.00"
+          },
+          %{
+            "name" => "Linen Notebook Cover",
+            "variant" => "Natural",
+            "sku" => "LNC-A5-NAT",
+            "qty" => 1,
+            "price" => "£22.00"
+          }
+        ],
+        "address" => "55 Victoria Road, Birmingham, B16 9LA",
+        "timeline" => [
+          %{"event" => "Order placed", "time" => "28 Feb 2026, 20:14"},
+          %{"event" => "Payment confirmed", "time" => "28 Feb 2026, 20:14"},
+          %{"event" => "Packed", "time" => "1 Mar 2026, 11:00"},
+          %{"event" => "Dispatched — Royal Mail Tracked 24", "time" => "1 Mar 2026, 11:30"},
+          %{"event" => "Delivered", "time" => "2 Mar 2026, 10:05"}
+        ]
+      },
+      %{
+        "id" => "#1035",
+        "ref" => "ord_1035",
+        "customer" => "Sarah Mitchell",
+        "customer_id" => "cust_001",
+        "email" => "sarah.mitchell@example.com",
+        "date" => "25 Feb 2026",
+        "status" => "fulfilled",
+        "fulfillment" => "fulfilled",
+        "payment" => "paid",
+        "subtotal" => "£89.00",
+        "shipping" => "£4.95",
+        "tax" => "£18.80",
+        "total" => "£112.00",
+        "items" => [
+          %{
+            "name" => "Wool Throw — Natural",
+            "variant" => "Natural",
+            "sku" => "WTH-NAT-001",
+            "qty" => 1,
+            "price" => "£89.00"
+          }
+        ],
+        "address" => "14 Elm Street, Bristol, BS1 4RQ",
+        "timeline" => [
+          %{"event" => "Order placed", "time" => "25 Feb 2026, 16:44"},
+          %{"event" => "Payment confirmed", "time" => "25 Feb 2026, 16:44"},
+          %{"event" => "Packed", "time" => "26 Feb 2026, 09:30"},
+          %{"event" => "Dispatched — Royal Mail Tracked 48", "time" => "26 Feb 2026, 10:00"},
+          %{"event" => "Delivered", "time" => "28 Feb 2026, 12:15"}
+        ]
+      }
+    ]
+  end
+
+  def order(id), do: Enum.find(orders(), &(&1["id"] == id || &1["ref"] == id))
+
+  # ── Customers ─────────────────────────────────────────────────────────────
+
+  def customers do
+    [
+      %{
+        "id" => "cust_001",
+        "name" => "Sarah Mitchell",
+        "email" => "sarah.mitchell@example.com",
+        "joined" => "14 Jan 2026",
+        "ltv" => "£340.00",
+        "order_count" => 4,
+        "avg_order" => "£85.00",
+        "return_rate" => "0%",
+        "location" => "Bristol, UK",
+        "segment" => "Loyal",
+        "recent_orders" => ["#1042", "#1035"]
+      },
+      %{
+        "id" => "cust_002",
+        "name" => "James Cooper",
+        "email" => "james.cooper@example.com",
+        "joined" => "3 Sep 2025",
+        "ltv" => "£1,204.50",
+        "order_count" => 9,
+        "avg_order" => "£133.83",
+        "return_rate" => "0%",
+        "location" => "Edinburgh, UK",
+        "segment" => "VIP",
+        "recent_orders" => ["#1041", "#1037"]
+      },
+      %{
+        "id" => "cust_003",
+        "name" => "Emma Walsh",
+        "email" => "emma.walsh@example.com",
+        "joined" => "22 Feb 2026",
+        "ltv" => "£45.00",
+        "order_count" => 1,
+        "avg_order" => "£45.00",
+        "return_rate" => "0%",
+        "location" => "Oxford, UK",
+        "segment" => "New",
+        "recent_orders" => ["#1040"]
+      },
+      %{
+        "id" => "cust_004",
+        "name" => "Oliver Park",
+        "email" => "o.park@example.com",
+        "joined" => "8 Nov 2025",
+        "ltv" => "£612.00",
+        "order_count" => 5,
+        "avg_order" => "£122.40",
+        "return_rate" => "0%",
+        "location" => "Manchester, UK",
+        "segment" => "Loyal",
+        "recent_orders" => ["#1039"]
+      },
+      %{
+        "id" => "cust_005",
+        "name" => "Lily Chen",
+        "email" => "lily.chen@example.com",
+        "joined" => "19 Jan 2026",
+        "ltv" => "£189.00",
+        "order_count" => 3,
+        "avg_order" => "£63.00",
+        "return_rate" => "0%",
+        "location" => "London, UK",
+        "segment" => "Regular",
+        "recent_orders" => ["#1038"]
+      },
+      %{
+        "id" => "cust_006",
+        "name" => "Priya Nair",
+        "email" => "priya.nair@example.com",
+        "joined" => "1 Feb 2026",
+        "ltv" => "£256.00",
+        "order_count" => 2,
+        "avg_order" => "£128.00",
+        "return_rate" => "0%",
+        "location" => "Birmingham, UK",
+        "segment" => "Regular",
+        "recent_orders" => ["#1036"]
+      }
+    ]
+  end
+
+  def customer(id), do: Enum.find(customers(), &(&1["id"] == id))
+
+  # ── Promotions ────────────────────────────────────────────────────────────
+
+  def promotions do
+    [
+      %{
+        "id" => "promo_001",
+        "code" => "SUMMER20",
+        "description" => "20% off sitewide",
+        "type" => "percentage",
+        "value" => "20%",
+        "uses" => 145,
+        "max_uses" => nil,
+        "revenue_impact" => "£1,204.40",
+        "expires" => "30 Jun 2026",
+        "status" => "active",
+        "conditions" => "No minimum order"
+      },
+      %{
+        "id" => "promo_002",
+        "code" => "WELCOME10",
+        "description" => "£10 off first order",
+        "type" => "fixed",
+        "value" => "£10",
+        "uses" => 892,
+        "max_uses" => nil,
+        "revenue_impact" => "£8,920.00",
+        "expires" => nil,
+        "status" => "active",
+        "conditions" => "First order only, min. £30"
+      },
+      %{
+        "id" => "promo_003",
+        "code" => "FLASH50",
+        "description" => "50% off sale items",
+        "type" => "percentage",
+        "value" => "50%",
+        "uses" => 0,
+        "max_uses" => 100,
+        "revenue_impact" => "£0",
+        "expires" => "31 Jan 2026",
+        "status" => "expired",
+        "conditions" => "Sale items only"
+      }
+    ]
+  end
+
+  # ── Helpers ───────────────────────────────────────────────────────────────
+
+  def initials(name) do
+    name
+    |> String.split()
+    |> Enum.map(&String.first/1)
+    |> Enum.take(2)
+    |> Enum.join()
+    |> String.upcase()
+  end
+
+  def stock_pct(stock, reorder_at) when reorder_at > 0 do
+    min(round(stock / (reorder_at * 3) * 100), 100)
+  end
+
+  def stock_pct(_, _), do: 100
+
+  def stock_class(stock, _reorder_at) when stock == 0, do: "low"
+  def stock_class(stock, reorder_at) when stock <= reorder_at, do: "low"
+  def stock_class(_, _), do: "ok"
+
+  def status_badge("published"), do: {"Published", "j-badge-green"}
+  def status_badge("active"), do: {"Active", "j-badge-green"}
+  def status_badge("fulfilled"), do: {"Fulfilled", "j-badge-green"}
+  def status_badge("pending"), do: {"Pending", "j-badge-amber"}
+  def status_badge("draft"), do: {"Draft", "j-badge-muted"}
+  def status_badge("unfulfilled"), do: {"Unfulfilled", "j-badge-amber"}
+  def status_badge("refunded"), do: {"Refunded", "j-badge-red"}
+  def status_badge("expired"), do: {"Expired", "j-badge-muted"}
+  def status_badge("out_of_stock"), do: {"Out of stock", "j-badge-red"}
+  def status_badge(s), do: {String.capitalize(s || ""), "j-badge-muted"}
+end

--- a/lib/jarga_admin/renderer.ex
+++ b/lib/jarga_admin/renderer.ex
@@ -39,24 +39,6 @@ defmodule JargaAdmin.Renderer do
     }
   end
 
-  defp normalize_component(%{"type" => "data_table"} = spec) do
-    data = spec["data"] || %{}
-
-    %{
-      type: :data_table,
-      assigns: %{
-        id: "tbl-#{:erlang.unique_integer([:positive])}",
-        title: spec["title"],
-        columns: normalize_columns(data["columns"] || []),
-        rows: data["rows"] || [],
-        actions: data["actions"] || [],
-        sort_key: nil,
-        sort_dir: :asc,
-        on_sort: nil
-      }
-    }
-  end
-
   defp normalize_component(%{"type" => "detail_card"} = spec) do
     data = spec["data"] || %{}
 
@@ -124,9 +106,88 @@ defmodule JargaAdmin.Renderer do
     %{
       type: :empty_state,
       assigns: %{
-        icon: data["icon"] || "📭",
+        icon: nil,
         title: data["title"] || "Nothing here yet",
         message: data["message"]
+      }
+    }
+  end
+
+  defp normalize_component(%{"type" => "stat_bar", "data" => data}) do
+    %{type: :stat_bar, assigns: %{stats: data["stats"] || []}}
+  end
+
+  defp normalize_component(%{"type" => "product_grid"} = spec) do
+    data = spec["data"] || %{}
+
+    %{
+      type: :product_grid,
+      assigns: %{
+        title: spec["title"],
+        products: data["products"] || [],
+        on_click: data["on_click"] || "view_product"
+      }
+    }
+  end
+
+  defp normalize_component(%{"type" => "order_detail"} = spec) do
+    %{type: :order_detail, assigns: %{order: spec["data"] || %{}}}
+  end
+
+  defp normalize_component(%{"type" => "product_detail"} = spec) do
+    %{type: :product_detail, assigns: %{product: spec["data"] || %{}}}
+  end
+
+  defp normalize_component(%{"type" => "customer_detail"} = spec) do
+    data = spec["data"] || %{}
+
+    %{
+      type: :customer_detail,
+      assigns: %{
+        customer: data["customer"] || data,
+        recent_orders: data["recent_orders"] || []
+      }
+    }
+  end
+
+  defp normalize_component(%{"type" => "promotion_list"} = spec) do
+    data = spec["data"] || %{}
+
+    %{
+      type: :promotion_list,
+      assigns: %{title: spec["title"] || "Promotions", promotions: data["promotions"] || []}
+    }
+  end
+
+  defp normalize_component(%{"type" => "inventory_table"} = spec) do
+    data = spec["data"] || %{}
+
+    %{
+      type: :inventory_table,
+      assigns: %{
+        title: spec["title"] || "Inventory",
+        rows: data["rows"] || [],
+        on_restock: data["on_restock"] || "restock_item"
+      }
+    }
+  end
+
+  defp normalize_component(%{"type" => "data_table"} = spec) do
+    data = spec["data"] || %{}
+
+    %{
+      type: :data_table,
+      assigns: %{
+        id: "tbl-#{:erlang.unique_integer([:positive])}",
+        title: spec["title"],
+        columns: normalize_columns(data["columns"] || []),
+        rows: data["rows"] || [],
+        actions: data["actions"] || [],
+        on_row_click: data["on_row_click"],
+        sort_key: nil,
+        sort_dir: :asc,
+        on_sort: nil,
+        empty_message: data["empty_message"] || "No data to display"
       }
     }
   end

--- a/lib/jarga_admin/tab_store.ex
+++ b/lib/jarga_admin/tab_store.ex
@@ -44,6 +44,24 @@ defmodule JargaAdmin.TabStore do
       refresh_interval: :off,
       position: 2,
       pinnable: true
+    },
+    %{
+      id: "customers",
+      label: "Customers",
+      icon: "",
+      ui_spec: nil,
+      refresh_interval: :off,
+      position: 3,
+      pinnable: true
+    },
+    %{
+      id: "promotions",
+      label: "Promotions",
+      icon: "",
+      ui_spec: nil,
+      refresh_interval: :off,
+      position: 4,
+      pinnable: true
     }
   ]
 
@@ -76,7 +94,7 @@ defmodule JargaAdmin.TabStore do
 
   # Patch any existing default tab that still has nil spec (e.g. old server run)
   defp reseed_defaults do
-    ["dashboard", "orders", "products"]
+    ["dashboard", "orders", "products", "customers", "promotions"]
     |> Enum.each(fn id ->
       case get(id) do
         {:ok, %{ui_spec: nil} = tab} -> put(%{tab | ui_spec: default_spec(id)})
@@ -95,33 +113,59 @@ defmodule JargaAdmin.TabStore do
 
   # Pre-baked UI specs so default tabs show data immediately (no agent call needed)
   defp default_spec("dashboard") do
+    orders = JargaAdmin.MockData.orders()
+    recent = Enum.take(orders, 5)
+
     %{
       "layout" => "full",
       "components" => [
         %{
-          "type" => "metric_grid",
+          "type" => "stat_bar",
           "data" => %{
-            "metrics" => [
+            "stats" => [
+              %{
+                "label" => "Revenue today",
+                "value" => "£1,247",
+                "delta" => "↑ 12% vs yesterday",
+                "delta_up" => true
+              },
+              %{
+                "label" => "Orders today",
+                "value" => "14",
+                "delta" => "↑ 8% vs yesterday",
+                "delta_up" => true
+              },
+              %{
+                "label" => "Avg order value",
+                "value" => "£89.07",
+                "delta" => "↑ 4% vs yesterday",
+                "delta_up" => true
+              },
+              %{"label" => "Pending fulfilment", "value" => "3", "delta" => nil}
+            ]
+          }
+        },
+        %{
+          "type" => "chart",
+          "title" => "Revenue — last 7 days",
+          "data" => %{
+            "type" => "line",
+            "labels" => ["26 Feb", "27 Feb", "28 Feb", "1 Mar", "2 Mar", "3 Mar", "4 Mar"],
+            "datasets" => [
               %{
                 "label" => "Revenue",
-                "value" => "£1,247",
-                "trend" => 12.4,
-                "subtitle" => "Today"
-              },
-              %{"label" => "Orders", "value" => "14", "trend" => 7.7, "subtitle" => "Today"},
-              %{
-                "label" => "Avg Order Value",
-                "value" => "£89.07",
-                "trend" => 4.2,
-                "subtitle" => "Today"
-              },
-              %{"label" => "Returns", "value" => "1", "trend" => -50.0, "subtitle" => "Today"}
+                "data" => [890, 1240, 760, 1100, 980, 1380, 1247],
+                "borderColor" => "#181512",
+                "backgroundColor" => "rgba(24,21,18,0.06)",
+                "tension" => 0.4,
+                "fill" => true
+              }
             ]
           }
         },
         %{
           "type" => "data_table",
-          "title" => "Recent Orders",
+          "title" => "Recent orders",
           "data" => %{
             "columns" => [
               %{"key" => "id", "label" => "Order"},
@@ -130,52 +174,46 @@ defmodule JargaAdmin.TabStore do
               %{"key" => "status", "label" => "Status"},
               %{"key" => "date", "label" => "Date"}
             ],
-            "rows" => [
-              %{
-                "id" => "#1042",
-                "customer" => "Sarah Mitchell",
-                "total" => "£89.00",
-                "status" => "pending",
-                "date" => "4 Mar 2026"
-              },
-              %{
-                "id" => "#1041",
-                "customer" => "James Cooper",
-                "total" => "£234.50",
-                "status" => "fulfilled",
-                "date" => "3 Mar 2026"
-              },
-              %{
-                "id" => "#1040",
-                "customer" => "Emma Walsh",
-                "total" => "£45.00",
-                "status" => "pending",
-                "date" => "3 Mar 2026"
-              },
-              %{
-                "id" => "#1039",
-                "customer" => "Oliver Park",
-                "total" => "£178.00",
-                "status" => "fulfilled",
-                "date" => "2 Mar 2026"
-              }
-            ]
+            "rows" =>
+              Enum.map(recent, &Map.take(&1, ["id", "customer", "total", "status", "date"])),
+            "on_row_click" => "view_order"
           }
         },
         %{
-          "type" => "data_table",
-          "title" => "Low Stock Items",
+          "type" => "inventory_table",
+          "title" => "Low stock",
           "data" => %{
-            "columns" => [
-              %{"key" => "name", "label" => "Product"},
-              %{"key" => "stock", "label" => "Stock"},
-              %{"key" => "reorder_at", "label" => "Reorder Point"}
-            ],
             "rows" => [
-              %{"name" => "Beeswax Candle Set", "stock" => "0", "reorder_at" => "10"},
-              %{"name" => "Canvas Tote Bag", "stock" => "3", "reorder_at" => "15"},
-              %{"name" => "Oak Serving Board", "stock" => "2", "reorder_at" => "5"}
-            ]
+              %{
+                "id" => "prod_002",
+                "name" => "Canvas Tote Bag",
+                "sku" => "CTB-NAT-001",
+                "stock" => 3,
+                "reorder_at" => 20
+              },
+              %{
+                "id" => "prod_004",
+                "name" => "Oak Serving Board",
+                "sku" => "OSB-LRG-001",
+                "stock" => 2,
+                "reorder_at" => 8
+              },
+              %{
+                "id" => "prod_005",
+                "name" => "Beeswax Candle Set",
+                "sku" => "BWC-SET-3",
+                "stock" => 0,
+                "reorder_at" => 15
+              },
+              %{
+                "id" => "prod_008",
+                "name" => "Linen Notebook Cover",
+                "sku" => "LNC-A5-001",
+                "stock" => 8,
+                "reorder_at" => 12
+              }
+            ],
+            "on_restock" => "restock_item"
           }
         }
       ]
@@ -183,58 +221,52 @@ defmodule JargaAdmin.TabStore do
   end
 
   defp default_spec("orders") do
+    orders = JargaAdmin.MockData.orders()
+
     %{
       "layout" => "full",
       "components" => [
         %{
+          "type" => "stat_bar",
+          "data" => %{
+            "stats" => [
+              %{"label" => "Total orders", "value" => "#{length(orders)}"},
+              %{
+                "label" => "Pending",
+                "value" => "#{Enum.count(orders, &(&1["status"] == "pending"))}",
+                "delta" => nil
+              },
+              %{
+                "label" => "Fulfilled",
+                "value" => "#{Enum.count(orders, &(&1["status"] == "fulfilled"))}",
+                "delta" => nil
+              },
+              %{
+                "label" => "Refunded",
+                "value" => "#{Enum.count(orders, &(&1["status"] == "refunded"))}",
+                "delta" => nil
+              }
+            ]
+          }
+        },
+        %{
           "type" => "data_table",
-          "title" => "All Orders",
+          "title" => "All orders",
           "data" => %{
             "columns" => [
               %{"key" => "id", "label" => "Order"},
               %{"key" => "customer", "label" => "Customer"},
               %{"key" => "total", "label" => "Total"},
-              %{"key" => "status", "label" => "Status"},
+              %{"key" => "fulfillment", "label" => "Fulfilment"},
+              %{"key" => "payment", "label" => "Payment"},
               %{"key" => "date", "label" => "Date"}
             ],
-            "rows" => [
-              %{
-                "id" => "#1042",
-                "customer" => "Sarah Mitchell",
-                "total" => "£89.00",
-                "status" => "pending",
-                "date" => "4 Mar 2026"
-              },
-              %{
-                "id" => "#1041",
-                "customer" => "James Cooper",
-                "total" => "£234.50",
-                "status" => "fulfilled",
-                "date" => "3 Mar 2026"
-              },
-              %{
-                "id" => "#1040",
-                "customer" => "Emma Walsh",
-                "total" => "£45.00",
-                "status" => "pending",
-                "date" => "3 Mar 2026"
-              },
-              %{
-                "id" => "#1039",
-                "customer" => "Oliver Park",
-                "total" => "£178.00",
-                "status" => "fulfilled",
-                "date" => "2 Mar 2026"
-              },
-              %{
-                "id" => "#1038",
-                "customer" => "Lily Chen",
-                "total" => "£67.00",
-                "status" => "pending",
-                "date" => "2 Mar 2026"
-              }
-            ],
-            "actions" => [%{"label" => "View", "event" => "view_order"}]
+            "rows" =>
+              Enum.map(
+                orders,
+                &Map.take(&1, ["id", "customer", "total", "fulfillment", "payment", "date"])
+              ),
+            "on_row_click" => "view_order"
           }
         }
       ]
@@ -242,59 +274,121 @@ defmodule JargaAdmin.TabStore do
   end
 
   defp default_spec("products") do
+    products = JargaAdmin.MockData.products()
+    low_stock = Enum.filter(products, &(&1["stock"] <= &1["reorder_at"]))
+
     %{
       "layout" => "full",
       "components" => [
         %{
+          "type" => "stat_bar",
+          "data" => %{
+            "stats" => [
+              %{"label" => "Total products", "value" => "#{length(products)}"},
+              %{
+                "label" => "Published",
+                "value" => "#{Enum.count(products, &(&1["status"] == "published"))}"
+              },
+              %{
+                "label" => "Draft",
+                "value" => "#{Enum.count(products, &(&1["status"] == "draft"))}"
+              },
+              %{"label" => "Low / out of stock", "value" => "#{length(low_stock)}"}
+            ]
+          }
+        },
+        %{
+          "type" => "product_grid",
+          "title" => "All products",
+          "data" => %{
+            "products" => products,
+            "on_click" => "view_product"
+          }
+        }
+      ]
+    }
+  end
+
+  defp default_spec("customers") do
+    customers = JargaAdmin.MockData.customers()
+
+    %{
+      "layout" => "full",
+      "components" => [
+        %{
+          "type" => "stat_bar",
+          "data" => %{
+            "stats" => [
+              %{"label" => "Total customers", "value" => "#{length(customers)}"},
+              %{
+                "label" => "VIP",
+                "value" => "#{Enum.count(customers, &(&1["segment"] == "VIP"))}"
+              },
+              %{
+                "label" => "Loyal",
+                "value" => "#{Enum.count(customers, &(&1["segment"] == "Loyal"))}"
+              },
+              %{
+                "label" => "New (30d)",
+                "value" => "#{Enum.count(customers, &(&1["segment"] == "New"))}"
+              }
+            ]
+          }
+        },
+        %{
           "type" => "data_table",
-          "title" => "Products",
+          "title" => "All customers",
           "data" => %{
             "columns" => [
-              %{"key" => "name", "label" => "Product"},
-              %{"key" => "sku", "label" => "SKU"},
-              %{"key" => "price", "label" => "Price"},
-              %{"key" => "stock", "label" => "Stock"},
-              %{"key" => "status", "label" => "Status"}
+              %{"key" => "name", "label" => "Customer"},
+              %{"key" => "email", "label" => "Email"},
+              %{"key" => "ltv", "label" => "Lifetime value"},
+              %{"key" => "order_count", "label" => "Orders"},
+              %{"key" => "segment", "label" => "Segment"},
+              %{"key" => "joined", "label" => "Joined"}
             ],
-            "rows" => [
-              %{
-                "name" => "Leather Journal A5",
-                "sku" => "LJ-A5-001",
-                "price" => "£34.99",
-                "stock" => "40",
-                "status" => "published"
-              },
-              %{
-                "name" => "Canvas Tote Bag",
-                "sku" => "CTB-NAT-001",
-                "price" => "£24.99",
-                "stock" => "3",
-                "status" => "published"
-              },
-              %{
-                "name" => "Ceramic Mug — Slate",
-                "sku" => "MUG-SL-001",
-                "price" => "£18.00",
-                "stock" => "120",
-                "status" => "published"
-              },
-              %{
-                "name" => "Oak Serving Board",
-                "sku" => "OSB-001",
-                "price" => "£42.00",
-                "stock" => "2",
-                "status" => "published"
-              },
-              %{
-                "name" => "Beeswax Candle Set",
-                "sku" => "BWC-SET-001",
-                "price" => "£28.00",
-                "stock" => "0",
-                "status" => "draft"
-              }
-            ],
-            "actions" => [%{"label" => "Edit", "event" => "edit_product"}]
+            "rows" =>
+              Enum.map(
+                customers,
+                &Map.take(&1, ["id", "name", "email", "ltv", "order_count", "segment", "joined"])
+              ),
+            "on_row_click" => "view_customer"
           }
+        }
+      ]
+    }
+  end
+
+  defp default_spec("promotions") do
+    promotions = JargaAdmin.MockData.promotions()
+
+    %{
+      "layout" => "full",
+      "components" => [
+        %{
+          "type" => "stat_bar",
+          "data" => %{
+            "stats" => [
+              %{
+                "label" => "Active promotions",
+                "value" => "#{Enum.count(promotions, &(&1["status"] == "active"))}"
+              },
+              %{
+                "label" => "Total uses",
+                "value" => "#{Enum.sum(Enum.map(promotions, &(&1["uses"] || 0)))}"
+              },
+              %{"label" => "Discount issued", "value" => "£10,124"},
+              %{
+                "label" => "Expired",
+                "value" => "#{Enum.count(promotions, &(&1["status"] == "expired"))}"
+              }
+            ]
+          }
+        },
+        %{
+          "type" => "promotion_list",
+          "title" => "All promotions",
+          "data" => %{"promotions" => promotions}
         }
       ]
     }

--- a/lib/jarga_admin_web/components/jarga_components.ex
+++ b/lib/jarga_admin_web/components/jarga_components.ex
@@ -40,6 +40,7 @@ defmodule JargaAdminWeb.JargaComponents do
   attr :sort_key, :atom, default: nil
   attr :sort_dir, :atom, default: :asc
   attr :on_sort, :string, default: nil
+  attr :on_row_click, :string, default: nil
   attr :actions, :list, default: []
   attr :empty_message, :string, default: "No data to display"
 
@@ -71,7 +72,12 @@ defmodule JargaAdminWeb.JargaComponents do
             </tr>
           </thead>
           <tbody>
-            <tr :for={row <- @rows}>
+            <tr
+              :for={row <- @rows}
+              phx-click={@on_row_click}
+              phx-value-id={@on_row_click && row_id(row)}
+              style={if @on_row_click, do: "cursor:pointer;", else: ""}
+            >
               <td :for={col <- @columns}>
                 {render_cell(row, col)}
               </td>
@@ -80,10 +86,10 @@ defmodule JargaAdminWeb.JargaComponents do
                   <button
                     :for={action <- @actions}
                     class="j-btn j-btn-ghost j-btn-sm"
-                    phx-click={action[:event]}
+                    phx-click={action[:event] || action["event"]}
                     phx-value-id={row_id(row)}
                   >
-                    {action[:label]}
+                    {action[:label] || action["label"]}
                   </button>
                 </div>
               </td>
@@ -598,6 +604,724 @@ defmodule JargaAdminWeb.JargaComponents do
           style="width:100%;height:100%;"
         >
         </canvas>
+      </div>
+    </div>
+    """
+  end
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # StatBar
+  # ──────────────────────────────────────────────────────────────────────────
+
+  attr :stats, :list, required: true
+
+  def stat_bar(assigns) do
+    ~H"""
+    <div class="j-stat-bar">
+      <div :for={s <- @stats} class="j-stat-bar-item">
+        <div class="j-stat-bar-value">{s["value"] || s[:value]}</div>
+        <div class="j-stat-bar-label">{s["label"] || s[:label]}</div>
+        <div
+          :if={s["delta"] || s[:delta]}
+          class={"j-stat-bar-delta #{if s["delta_up"] != false && s[:delta_up] != false, do: "j-trend-up", else: "j-trend-down"}"}
+        >
+          {s["delta"] || s[:delta]}
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # Breadcrumb
+  # ──────────────────────────────────────────────────────────────────────────
+
+  attr :crumbs, :list, required: true
+
+  def breadcrumb(assigns) do
+    ~H"""
+    <div class="j-breadcrumb">
+      <span :for={{crumb, idx} <- Enum.with_index(@crumbs)}>
+        <span :if={idx > 0} class="j-breadcrumb-sep">/</span>
+        <button
+          :if={crumb["event"] || crumb[:event]}
+          class="j-breadcrumb-link"
+          phx-click={crumb["event"] || crumb[:event]}
+          phx-value-id={crumb["value"] || crumb[:value]}
+        >
+          {crumb["label"] || crumb[:label]}
+        </button>
+        <span
+          :if={!(crumb["event"] || crumb[:event])}
+          class="j-breadcrumb-current"
+        >
+          {crumb["label"] || crumb[:label]}
+        </span>
+      </span>
+    </div>
+    """
+  end
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # ActionBar
+  # ──────────────────────────────────────────────────────────────────────────
+
+  attr :actions, :list, required: true
+  attr :back_event, :string, default: nil
+  attr :back_label, :string, default: "Back"
+
+  def action_bar(assigns) do
+    ~H"""
+    <div class="j-action-bar">
+      <button
+        :if={@back_event}
+        class="j-back-btn"
+        phx-click={@back_event}
+      >
+        <span class="j-back-btn-arrow">←</span> {@back_label}
+      </button>
+      <span :if={@back_event} style="flex:1;" />
+      <button
+        :for={action <- @actions}
+        class={"j-btn j-btn-sm #{if (action["style"] || action[:style]) == "solid", do: "j-btn-solid", else: "j-btn-ghost"}"}
+        phx-click={action["event"] || action[:event]}
+        phx-value-id={action["value"] || action[:value]}
+      >
+        {action["label"] || action[:label]}
+      </button>
+    </div>
+    """
+  end
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # ProductGrid
+  # ──────────────────────────────────────────────────────────────────────────
+
+  attr :title, :string, default: nil
+  attr :products, :list, required: true
+  attr :on_click, :string, default: "view_product"
+
+  def product_grid(assigns) do
+    ~H"""
+    <div>
+      <div :if={@title} class="j-section-header" style="margin-bottom:16px;">
+        <p class="j-section-title">{@title}</p>
+      </div>
+      <div class="j-product-grid">
+        <div
+          :for={p <- @products}
+          class="j-product-card"
+          phx-click={@on_click}
+          phx-value-id={p["id"] || p[:id]}
+        >
+          <div class="j-product-card-img">
+            {p["sku"] || p[:sku]}
+          </div>
+          <div class="j-product-card-body">
+            <p class="j-product-card-name">{p["name"] || p[:name]}</p>
+            <div style="display:flex;align-items:baseline;gap:4px;">
+              <span class="j-product-card-price">{p["price"] || p[:price]}</span>
+              <span :if={p["compare_at"] || p[:compare_at]} class="j-product-card-compare">
+                {p["compare_at"] || p[:compare_at]}
+              </span>
+            </div>
+            <p class="j-product-card-stock">
+              {stock_label(p["stock"] || p[:stock])}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  defp stock_label(nil), do: ""
+  defp stock_label(0), do: "Out of stock"
+  defp stock_label(n) when is_integer(n) and n <= 5, do: "#{n} left"
+  defp stock_label(n) when is_integer(n), do: "#{n} in stock"
+  defp stock_label(s) when is_binary(s), do: stock_label(String.to_integer(s))
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # OrderDetail
+  # ──────────────────────────────────────────────────────────────────────────
+
+  attr :order, :map, required: true
+  attr :on_back, :string, default: "clear_detail"
+
+  def order_detail(assigns) do
+    {status_text, status_class} =
+      JargaAdmin.MockData.status_badge(assigns.order["status"] || "")
+
+    assigns = assign(assigns, status_text: status_text, status_class: status_class)
+
+    ~H"""
+    <div>
+      <button class="j-back-btn" phx-click={@on_back}>
+        <span class="j-back-btn-arrow">←</span> Orders
+      </button>
+
+      <div class="j-breadcrumb">
+        <button class="j-breadcrumb-link" phx-click={@on_back}>Orders</button>
+        <span class="j-breadcrumb-sep">/</span>
+        <span class="j-breadcrumb-current">{@order["id"]}</span>
+      </div>
+
+      <div style="display:flex;align-items:center;gap:14px;margin-bottom:24px;">
+        <h1 style="font-family:'Noto Serif Display',Georgia,serif;font-size:clamp(1.4rem,3vw,2rem);font-weight:600;color:var(--text-primary);">
+          Order {@order["id"]}
+        </h1>
+        <span class={"j-badge #{@status_class}"}>{@status_text}</span>
+      </div>
+
+      <div class="j-kpi-row">
+        <div>
+          <p class="j-kpi-label">Order total</p>
+          <p class="j-kpi-value">{@order["total"]}</p>
+        </div>
+        <div>
+          <p class="j-kpi-label">Items</p>
+          <p class="j-kpi-value">{length(@order["items"] || [])}</p>
+        </div>
+        <div>
+          <p class="j-kpi-label">Date placed</p>
+          <p class="j-kpi-value" style="font-size:1rem;">{@order["date"]}</p>
+        </div>
+        <div>
+          <p class="j-kpi-label">Payment</p>
+          <p class="j-kpi-value" style="font-size:1rem;">
+            {String.capitalize(@order["payment"] || "")}
+          </p>
+        </div>
+      </div>
+
+      <div class="j-detail-grid">
+        <%!-- Left: line items --%>
+        <div>
+          <div class="j-card" style="padding:20px 24px;">
+            <p class="j-card-title">Items</p>
+            <table class="j-line-items">
+              <tbody>
+                <tr :for={item <- @order["items"] || []}>
+                  <td style="padding-right:16px;">
+                    <span class="j-li-name">{item["name"]}</span>
+                    <span class="j-li-variant">{item["variant"]} · {item["sku"]}</span>
+                  </td>
+                  <td class="j-li-qty">× {item["qty"]}</td>
+                  <td class="j-li-total">{item["price"]}</td>
+                </tr>
+              </tbody>
+            </table>
+            <table class="j-totals" style="margin-top:16px;">
+              <tr>
+                <td>Subtotal</td>
+                <td>{@order["subtotal"]}</td>
+              </tr>
+              <tr>
+                <td>Shipping</td>
+                <td>{@order["shipping"]}</td>
+              </tr>
+              <tr>
+                <td>Tax (VAT 20%)</td>
+                <td>{@order["tax"]}</td>
+              </tr>
+              <tr class="total">
+                <td>Total</td>
+                <td>{@order["total"]}</td>
+              </tr>
+            </table>
+          </div>
+
+          <%!-- Timeline --%>
+          <div class="j-card" style="padding:20px 24px;margin-top:16px;">
+            <p class="j-card-title">Timeline</p>
+            <div class="j-timeline">
+              <div :for={event <- @order["timeline"] || []} class="j-timeline-item">
+                <div class="j-timeline-dot"></div>
+                <div>
+                  <p class="j-timeline-title">{event["event"]}</p>
+                  <p class="j-timeline-time">{event["time"]}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <%!-- Right: customer + address --%>
+        <div style="display:flex;flex-direction:column;gap:16px;">
+          <div class="j-card" style="padding:20px 24px;">
+            <p class="j-card-title">Customer</p>
+            <div style="display:flex;align-items:center;gap:12px;margin-bottom:16px;">
+              <div class="j-avatar">{JargaAdmin.MockData.initials(@order["customer"] || "?")}</div>
+              <div>
+                <p style="font-family:'Manrope',sans-serif;font-weight:600;font-size:0.9rem;color:var(--text-primary);">
+                  {@order["customer"]}
+                </p>
+                <p style="font-family:'Manrope',sans-serif;font-size:0.82rem;color:var(--text-faint);">
+                  {@order["email"]}
+                </p>
+              </div>
+            </div>
+            <div class="j-kv-list">
+              <div class="j-kv-row">
+                <span class="j-kv-key">Address</span>
+                <span class="j-kv-val">{@order["address"]}</span>
+              </div>
+              <div class="j-kv-row">
+                <span class="j-kv-key">Fulfillment</span>
+                <span class="j-kv-val">{String.capitalize(@order["fulfillment"] || "")}</span>
+              </div>
+            </div>
+          </div>
+
+          <div
+            class="j-action-bar"
+            style="margin-top:0;padding-top:0;border-top:none;flex-direction:column;align-items:stretch;gap:8px;"
+          >
+            <button
+              class="j-btn j-btn-solid j-btn-sm"
+              phx-click="fulfill_order"
+              phx-value-id={@order["id"]}
+            >
+              Mark as fulfilled
+            </button>
+            <button
+              class="j-btn j-btn-ghost j-btn-sm"
+              phx-click="refund_order"
+              phx-value-id={@order["id"]}
+            >
+              Issue refund
+            </button>
+            <button
+              class="j-btn j-btn-ghost j-btn-sm"
+              phx-click="view_customer"
+              phx-value-id={@order["customer_id"]}
+            >
+              View customer
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # ProductDetail
+  # ──────────────────────────────────────────────────────────────────────────
+
+  attr :product, :map, required: true
+  attr :on_back, :string, default: "clear_detail"
+
+  def product_detail(assigns) do
+    stock = assigns.product["stock"] || 0
+    reorder_at = assigns.product["reorder_at"] || 10
+    pct = JargaAdmin.MockData.stock_pct(stock, reorder_at)
+    bar_class = JargaAdmin.MockData.stock_class(stock, reorder_at)
+
+    {status_text, status_class} =
+      JargaAdmin.MockData.status_badge(assigns.product["status"] || "")
+
+    assigns =
+      assigns
+      |> assign(:stock_pct, pct)
+      |> assign(:bar_class, bar_class)
+      |> assign(:status_text, status_text)
+      |> assign(:status_class, status_class)
+
+    ~H"""
+    <div>
+      <button class="j-back-btn" phx-click={@on_back}>
+        <span class="j-back-btn-arrow">←</span> Products
+      </button>
+
+      <div class="j-breadcrumb">
+        <button class="j-breadcrumb-link" phx-click={@on_back}>Products</button>
+        <span class="j-breadcrumb-sep">/</span>
+        <span class="j-breadcrumb-current">{@product["name"]}</span>
+      </div>
+
+      <div style="display:flex;align-items:center;gap:14px;margin-bottom:24px;">
+        <h1 style="font-family:'Noto Serif Display',Georgia,serif;font-size:clamp(1.4rem,3vw,2rem);font-weight:600;color:var(--text-primary);">
+          {@product["name"]}
+        </h1>
+        <span class={"j-badge #{@status_class}"}>{@status_text}</span>
+      </div>
+
+      <div :if={@product["stock"] == 0} style="margin-bottom:20px;">
+        <.alert_banner
+          kind={:error}
+          title="Out of stock"
+          message="This product has no inventory. It is hidden from the storefront."
+        />
+      </div>
+      <div
+        :if={@product["stock"] != 0 && @product["stock"] <= @product["reorder_at"]}
+        style="margin-bottom:20px;"
+      >
+        <.alert_banner
+          kind={:warn}
+          title="Low stock"
+          message={"Only #{@product["stock"]} units remaining — below the reorder point of #{@product["reorder_at"]}."}
+        />
+      </div>
+
+      <div class="j-kpi-row">
+        <div>
+          <p class="j-kpi-label">Price</p>
+          <p class="j-kpi-value">{@product["price"]}</p>
+        </div>
+        <div>
+          <p class="j-kpi-label">Stock</p>
+          <p class="j-kpi-value">{@product["stock"]}</p>
+        </div>
+        <div>
+          <p class="j-kpi-label">Revenue (30d)</p>
+          <p class="j-kpi-value">{@product["revenue_30d"]}</p>
+        </div>
+        <div>
+          <p class="j-kpi-label">Units sold (30d)</p>
+          <p class="j-kpi-value">{@product["units_sold_30d"]}</p>
+        </div>
+      </div>
+
+      <div class="j-detail-grid">
+        <%!-- Left: product info --%>
+        <div style="display:flex;flex-direction:column;gap:16px;">
+          <div class="j-card" style="padding:20px 24px;">
+            <p class="j-card-title">Details</p>
+            <div class="j-kv-list">
+              <div class="j-kv-row">
+                <span class="j-kv-key">SKU</span>
+                <span
+                  class="j-kv-val"
+                  style="font-family:'Montserrat',sans-serif;font-size:0.85rem;letter-spacing:0.05em;"
+                >
+                  {@product["sku"]}
+                </span>
+              </div>
+              <div class="j-kv-row">
+                <span class="j-kv-key">Weight</span>
+                <span class="j-kv-val">{@product["weight"]}</span>
+              </div>
+              <div :if={@product["compare_at"]} class="j-kv-row">
+                <span class="j-kv-key">Compare at</span>
+                <span class="j-kv-val" style="text-decoration:line-through;">
+                  {@product["compare_at"]}
+                </span>
+              </div>
+              <div class="j-kv-row">
+                <span class="j-kv-key">Tags</span>
+                <span class="j-kv-val">{Enum.join(@product["tags"] || [], ", ")}</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="j-card" style="padding:20px 24px;">
+            <p class="j-card-title">Description</p>
+            <p style="font-family:'Manrope',sans-serif;font-size:0.9rem;color:var(--text-body);line-height:1.7;">
+              {@product["description"]}
+            </p>
+          </div>
+        </div>
+
+        <%!-- Right: inventory + variants --%>
+        <div style="display:flex;flex-direction:column;gap:16px;">
+          <div class="j-card" style="padding:20px 24px;">
+            <p class="j-card-title">Inventory</p>
+            <div style="margin-bottom:16px;">
+              <div style="display:flex;justify-content:space-between;margin-bottom:6px;">
+                <span class="j-eyebrow">Stock level</span>
+                <span style="font-family:'Manrope',sans-serif;font-size:0.82rem;color:var(--text-muted);">
+                  {@product["stock"]} / reorder at {@product["reorder_at"]}
+                </span>
+              </div>
+              <div class="j-inv-bar-wrap">
+                <div class={"j-inv-bar-fill #{@bar_class}"} style={"width:#{@stock_pct}%;"} />
+              </div>
+            </div>
+            <table class="j-table" style="width:100%;">
+              <thead>
+                <tr>
+                  <th>Variant</th>
+                  <th>SKU</th>
+                  <th style="text-align:right;">Stock</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr :for={v <- @product["variants"] || []}>
+                  <td>{v["name"]}</td>
+                  <td style="font-family:'Montserrat',sans-serif;font-size:0.78rem;letter-spacing:0.05em;color:var(--text-faint);">
+                    {v["sku"]}
+                  </td>
+                  <td style="text-align:right;">
+                    <span class={if v["stock"] == 0, do: "j-badge j-badge-red", else: ""}>
+                      {v["stock"]}
+                    </span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div style="display:flex;flex-direction:column;gap:8px;">
+            <button
+              class="j-btn j-btn-solid j-btn-sm"
+              phx-click="edit_product"
+              phx-value-id={@product["id"]}
+            >
+              Edit product
+            </button>
+            <button
+              class="j-btn j-btn-ghost j-btn-sm"
+              phx-click="duplicate_product"
+              phx-value-id={@product["id"]}
+            >
+              Duplicate
+            </button>
+            <button
+              class="j-btn j-btn-ghost j-btn-sm"
+              phx-click="archive_product"
+              phx-value-id={@product["id"]}
+            >
+              Archive
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # CustomerDetail
+  # ──────────────────────────────────────────────────────────────────────────
+
+  attr :customer, :map, required: true
+  attr :on_back, :string, default: "clear_detail"
+  attr :recent_orders, :list, default: []
+
+  def customer_detail(assigns) do
+    {seg_text, seg_class} = segment_badge(assigns.customer["segment"])
+    assigns = assign(assigns, seg_text: seg_text, seg_class: seg_class)
+
+    ~H"""
+    <div>
+      <button class="j-back-btn" phx-click={@on_back}>
+        <span class="j-back-btn-arrow">←</span> Customers
+      </button>
+
+      <div class="j-breadcrumb">
+        <button class="j-breadcrumb-link" phx-click={@on_back}>Customers</button>
+        <span class="j-breadcrumb-sep">/</span>
+        <span class="j-breadcrumb-current">{@customer["name"]}</span>
+      </div>
+
+      <div style="display:flex;align-items:center;gap:16px;margin-bottom:24px;">
+        <div class="j-avatar j-avatar-lg">
+          {JargaAdmin.MockData.initials(@customer["name"] || "?")}
+        </div>
+        <div>
+          <div style="display:flex;align-items:center;gap:10px;">
+            <h1 style="font-family:'Noto Serif Display',Georgia,serif;font-size:clamp(1.3rem,2.5vw,1.8rem);font-weight:600;color:var(--text-primary);">
+              {@customer["name"]}
+            </h1>
+            <span class={"j-badge #{@seg_class}"}>{@seg_text}</span>
+          </div>
+          <p style="font-family:'Manrope',sans-serif;font-size:0.88rem;color:var(--text-faint);margin-top:2px;">
+            {@customer["email"]} · {@customer["location"]}
+          </p>
+        </div>
+      </div>
+
+      <div class="j-kpi-row">
+        <div>
+          <p class="j-kpi-label">Lifetime value</p>
+          <p class="j-kpi-value">{@customer["ltv"]}</p>
+        </div>
+        <div>
+          <p class="j-kpi-label">Orders</p>
+          <p class="j-kpi-value">{@customer["order_count"]}</p>
+        </div>
+        <div>
+          <p class="j-kpi-label">Avg order value</p>
+          <p class="j-kpi-value">{@customer["avg_order"]}</p>
+        </div>
+        <div>
+          <p class="j-kpi-label">Return rate</p>
+          <p class="j-kpi-value">{@customer["return_rate"]}</p>
+        </div>
+      </div>
+
+      <div class="j-detail-grid">
+        <div>
+          <div class="j-card" style="padding:20px 24px;">
+            <p class="j-card-title">Recent orders</p>
+            <div :if={@recent_orders == []} class="j-empty-state" style="padding:24px;">
+              <p class="j-empty-text">No orders yet</p>
+            </div>
+            <table class="j-table" style="width:100%;">
+              <thead>
+                <tr>
+                  <th>Order</th>
+                  <th>Date</th>
+                  <th>Total</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  :for={ord <- @recent_orders}
+                  style="cursor:pointer;"
+                  phx-click="view_order"
+                  phx-value-id={ord["id"]}
+                >
+                  <td style="font-family:'Montserrat',sans-serif;font-size:0.82rem;font-weight:700;letter-spacing:0.05em;">
+                    {ord["id"]}
+                  </td>
+                  <td>{ord["date"]}</td>
+                  <td style="font-family:'Noto Serif Display',serif;font-weight:600;">
+                    {ord["total"]}
+                  </td>
+                  <td>{elem(JargaAdmin.MockData.status_badge(ord["status"]), 0)}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div style="display:flex;flex-direction:column;gap:16px;">
+          <div class="j-card" style="padding:20px 24px;">
+            <p class="j-card-title">Details</p>
+            <div class="j-kv-list">
+              <div class="j-kv-row">
+                <span class="j-kv-key">Customer since</span>
+                <span class="j-kv-val">{@customer["joined"]}</span>
+              </div>
+              <div class="j-kv-row">
+                <span class="j-kv-key">Segment</span>
+                <span class="j-kv-val">{@customer["segment"]}</span>
+              </div>
+              <div class="j-kv-row">
+                <span class="j-kv-key">Location</span>
+                <span class="j-kv-val">{@customer["location"]}</span>
+              </div>
+            </div>
+          </div>
+          <div style="display:flex;flex-direction:column;gap:8px;">
+            <button class="j-btn j-btn-solid j-btn-sm">Email customer</button>
+            <button class="j-btn j-btn-ghost j-btn-sm">Add note</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  defp segment_badge("VIP"), do: {"VIP", "j-badge-green"}
+  defp segment_badge("Loyal"), do: {"Loyal", "j-badge-green"}
+  defp segment_badge("Regular"), do: {"Regular", "j-badge-amber"}
+  defp segment_badge("New"), do: {"New", "j-badge-muted"}
+  defp segment_badge(s), do: {s || "", "j-badge-muted"}
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # PromotionList
+  # ──────────────────────────────────────────────────────────────────────────
+
+  attr :promotions, :list, required: true
+  attr :title, :string, default: "Promotions"
+
+  def promotion_list(assigns) do
+    ~H"""
+    <div>
+      <div class="j-section-header">
+        <p class="j-section-title">{@title}</p>
+      </div>
+      <div class="j-promo-list">
+        <div :for={promo <- @promotions} class="j-promo-card">
+          <div class="j-promo-left">
+            <div style="display:flex;align-items:center;gap:10px;margin-bottom:4px;">
+              <p class="j-promo-code">{promo["code"] || promo[:code]}</p>
+              <span class={promo_badge_class(promo["status"] || promo[:status])}>
+                {String.capitalize(promo["status"] || promo[:status] || "")}
+              </span>
+            </div>
+            <p class="j-promo-desc">{promo["description"] || promo[:description]}</p>
+            <p class="j-promo-meta">
+              {promo["value"] || promo[:value]} off {if promo["expires"] || promo[:expires],
+                do: "· Expires #{promo["expires"] || promo[:expires]}",
+                else: "· No expiry"} · {promo["conditions"] || promo[:conditions]}
+            </p>
+          </div>
+          <div class="j-promo-right">
+            <div class="j-promo-uses-value">{promo["uses"] || promo[:uses] || 0}</div>
+            <div class="j-promo-uses-label">uses</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  defp promo_badge_class("active"), do: "j-badge j-badge-green"
+  defp promo_badge_class("expired"), do: "j-badge j-badge-muted"
+  defp promo_badge_class(_), do: "j-badge j-badge-muted"
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # InventoryTable
+  # ──────────────────────────────────────────────────────────────────────────
+
+  attr :title, :string, default: "Inventory"
+  attr :rows, :list, required: true
+  attr :on_restock, :string, default: nil
+
+  def inventory_table(assigns) do
+    ~H"""
+    <div class="j-card" style="padding:20px 24px;">
+      <p class="j-card-title">{@title}</p>
+      <div class="j-table-wrap">
+        <table class="j-table" style="width:100%;">
+          <thead>
+            <tr>
+              <th>Product</th>
+              <th>SKU</th>
+              <th>Stock</th>
+              <th>Reorder at</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr :for={row <- @rows}>
+              <td style="font-weight:500;color:var(--text-primary);">{row["name"] || row[:name]}</td>
+              <td style="font-family:'Montserrat',sans-serif;font-size:0.78rem;letter-spacing:0.05em;color:var(--text-faint);">
+                {row["sku"] || row[:sku]}
+              </td>
+              <td>
+                <div style="display:flex;align-items:center;gap:10px;">
+                  <div class="j-inv-bar-wrap">
+                    <div
+                      class={"j-inv-bar-fill #{JargaAdmin.MockData.stock_class(row["stock"] || 0, row["reorder_at"] || 10)}"}
+                      style={"width:#{JargaAdmin.MockData.stock_pct(row["stock"] || 0, row["reorder_at"] || 10)}%;"}
+                    />
+                  </div>
+                  <span style="font-family:'Manrope',sans-serif;font-size:0.85rem;">
+                    {row["stock"] || row[:stock]}
+                  </span>
+                </div>
+              </td>
+              <td style="color:var(--text-faint);">{row["reorder_at"] || row[:reorder_at]}</td>
+              <td>
+                <button
+                  :if={@on_restock}
+                  class="j-btn j-btn-ghost j-btn-sm"
+                  phx-click={@on_restock}
+                  phx-value-id={row["id"] || row[:id]}
+                >
+                  Restock
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
     """

--- a/lib/jarga_admin_web/live/chat_live.ex
+++ b/lib/jarga_admin_web/live/chat_live.ex
@@ -17,7 +17,7 @@ defmodule JargaAdminWeb.ChatLive do
 
   use JargaAdminWeb, :live_view
 
-  alias JargaAdmin.{UiSpec, Renderer, TabStore}
+  alias JargaAdmin.{UiSpec, Renderer, TabStore, MockData}
   alias JargaAdmin.Quecto.MockBridge
   alias Phoenix.PubSub
 
@@ -56,6 +56,8 @@ defmodule JargaAdminWeb.ChatLive do
       |> assign(:rename_tab_id, nil)
       |> assign(:rename_value, "")
       |> assign(:chat_open, true)
+      # Detail panels
+      |> assign(:detail, nil)
 
     {:ok, socket}
   end
@@ -181,18 +183,23 @@ defmodule JargaAdminWeb.ChatLive do
     <%!-- Page --%>
     <div class="j-page">
       <div class="j-tab-page">
+        <%!-- Detail panel overrides everything else --%>
+        <div :if={@detail} class="j-canvas-block">
+          <.render_detail_panel detail={@detail} />
+        </div>
+
         <%!-- When the AI has generated a result, show it full-width --%>
-        <div :if={@rendered_components != []}>
+        <div :if={!@detail && @rendered_components != []}>
           <div class="j-tab-page-header">
             <p class="j-tab-page-label">Results</p>
           </div>
           <div :for={comp <- @rendered_components} class="j-canvas-block">
-            {render_component(comp, assigns)}
+            <.render_comp comp={comp} />
           </div>
         </div>
 
         <%!-- Otherwise show the active tab's own content --%>
-        <div :if={@rendered_components == []}>
+        <div :if={!@detail && @rendered_components == []}>
           <div class="j-tab-page-header">
             <p class="j-tab-page-label">
               {with tab <- find_tab(@tabs, @active_tab_id), do: tab && tab.label}
@@ -212,7 +219,7 @@ defmodule JargaAdminWeb.ChatLive do
                 :for={comp <- Renderer.render_spec(current_tab_spec(@tabs, @active_tab_id))}
                 class="j-canvas-block"
               >
-                {render_component(comp, assigns)}
+                <.render_comp comp={comp} />
               </div>
             </div>
           </div>
@@ -318,45 +325,201 @@ defmodule JargaAdminWeb.ChatLive do
   # Component renderer (inside LiveView)
   # ──────────────────────────────────────────────────────────────────────────
 
-  defp render_component(%{type: :metric_grid, assigns: a}, _outer) do
-    JargaAdminWeb.JargaComponents.metric_grid(a)
+  # ── HEEx component dispatcher (proper Phoenix components, not plain fn calls) ──
+
+  attr :comp, :map, required: true
+
+  defp render_comp(%{comp: %{type: :metric_grid, assigns: a}} = assigns) do
+    assigns = Map.merge(assigns, a)
+    ~H"<JargaAdminWeb.JargaComponents.metric_grid metrics={@metrics} />"
   end
 
-  defp render_component(%{type: :metric_card, assigns: a}, _outer) do
-    JargaAdminWeb.JargaComponents.metric_card(a)
+  defp render_comp(%{comp: %{type: :metric_card, assigns: a}} = assigns) do
+    assigns = Map.merge(assigns, a)
+    ~H"<JargaAdminWeb.JargaComponents.metric_card
+  label={@label}
+  value={@value}
+  trend={@trend}
+  subtitle={assigns[:subtitle]}
+/>"
   end
 
-  defp render_component(%{type: :data_table, assigns: a}, _outer) do
-    JargaAdminWeb.JargaComponents.data_table(a)
+  defp render_comp(%{comp: %{type: :data_table, assigns: a}} = assigns) do
+    assigns = Map.merge(assigns, a)
+
+    ~H"""
+    <JargaAdminWeb.JargaComponents.data_table
+      id={@id}
+      title={assigns[:title]}
+      columns={@columns}
+      rows={@rows}
+      actions={@actions}
+      on_row_click={assigns[:on_row_click]}
+      sort_key={@sort_key}
+      sort_dir={@sort_dir}
+      on_sort={assigns[:on_sort]}
+      empty_message={assigns[:empty_message] || "No data to display"}
+    />
+    """
   end
 
-  defp render_component(%{type: :detail_card, assigns: a}, _outer) do
-    JargaAdminWeb.JargaComponents.detail_card(a)
+  defp render_comp(%{comp: %{type: :detail_card, assigns: a}} = assigns) do
+    assigns = Map.merge(assigns, a)
+
+    ~H"""
+    <JargaAdminWeb.JargaComponents.detail_card
+      title={@title}
+      pairs={@pairs}
+      timeline={@timeline}
+      actions={@actions}
+    />
+    """
   end
 
-  defp render_component(%{type: :chart, assigns: a}, _outer) do
-    JargaAdminWeb.JargaComponents.chart(a)
+  defp render_comp(%{comp: %{type: :chart, assigns: a}} = assigns) do
+    assigns = Map.merge(assigns, a)
+
+    ~H"""
+    <JargaAdminWeb.JargaComponents.chart
+      id={@id}
+      title={assigns[:title]}
+      type={@type}
+      labels={@labels}
+      datasets={@datasets}
+      height={assigns[:height] || 280}
+    />
+    """
   end
 
-  defp render_component(%{type: :alert_banner, assigns: a}, _outer) do
-    JargaAdminWeb.JargaComponents.alert_banner(a)
+  defp render_comp(%{comp: %{type: :alert_banner, assigns: a}} = assigns) do
+    assigns = Map.merge(assigns, a)
+    ~H"<JargaAdminWeb.JargaComponents.alert_banner
+  kind={@kind}
+  title={assigns[:title]}
+  message={@message}
+/>"
   end
 
-  defp render_component(%{type: :dynamic_form, assigns: a}, _outer) do
-    JargaAdminWeb.JargaComponents.dynamic_form(a)
+  defp render_comp(%{comp: %{type: :dynamic_form, assigns: a}} = assigns) do
+    assigns = Map.merge(assigns, a)
+
+    ~H"""
+    <JargaAdminWeb.JargaComponents.dynamic_form
+      id={@id}
+      title={assigns[:title]}
+      fields={@fields}
+      values={@values}
+      submit_event={@submit_event}
+      cancel_event={@cancel_event}
+    />
+    """
   end
 
-  defp render_component(%{type: :empty_state, assigns: a}, _outer) do
-    JargaAdminWeb.JargaComponents.empty_state(a)
+  defp render_comp(%{comp: %{type: :empty_state, assigns: a}} = assigns) do
+    assigns = Map.merge(assigns, a)
+    ~H"<JargaAdminWeb.JargaComponents.empty_state
+  icon={assigns[:icon]}
+  title={@title}
+  message={assigns[:message]}
+/>"
   end
 
-  defp render_component(%{type: :unknown, assigns: %{raw: raw}}, _outer) do
-    Phoenix.HTML.raw(
-      "<pre style='font-size:0.75rem;overflow:auto;'>#{Jason.encode!(raw, pretty: true)}</pre>"
-    )
+  defp render_comp(%{comp: %{type: :stat_bar, assigns: a}} = assigns) do
+    assigns = Map.merge(assigns, a)
+    ~H"<JargaAdminWeb.JargaComponents.stat_bar stats={@stats} />"
   end
 
-  defp render_component(_, _), do: Phoenix.HTML.raw("")
+  defp render_comp(%{comp: %{type: :product_grid, assigns: a}} = assigns) do
+    assigns = Map.merge(assigns, a)
+
+    ~H"""
+    <JargaAdminWeb.JargaComponents.product_grid
+      title={assigns[:title]}
+      products={@products}
+      on_click={assigns[:on_click] || "view_product"}
+    />
+    """
+  end
+
+  defp render_comp(%{comp: %{type: :order_detail, assigns: a}} = assigns) do
+    assigns = Map.merge(assigns, a)
+    ~H"<JargaAdminWeb.JargaComponents.order_detail order={@order} />"
+  end
+
+  defp render_comp(%{comp: %{type: :product_detail, assigns: a}} = assigns) do
+    assigns = Map.merge(assigns, a)
+    ~H"<JargaAdminWeb.JargaComponents.product_detail product={@product} />"
+  end
+
+  defp render_comp(%{comp: %{type: :customer_detail, assigns: a}} = assigns) do
+    assigns = Map.merge(assigns, a)
+
+    ~H"""
+    <JargaAdminWeb.JargaComponents.customer_detail
+      customer={@customer}
+      recent_orders={@recent_orders}
+    />
+    """
+  end
+
+  defp render_comp(%{comp: %{type: :promotion_list, assigns: a}} = assigns) do
+    assigns = Map.merge(assigns, a)
+    ~H"<JargaAdminWeb.JargaComponents.promotion_list title={@title} promotions={@promotions} />"
+  end
+
+  defp render_comp(%{comp: %{type: :inventory_table, assigns: a}} = assigns) do
+    assigns = Map.merge(assigns, a)
+
+    ~H"""
+    <JargaAdminWeb.JargaComponents.inventory_table
+      title={@title}
+      rows={@rows}
+      on_restock={assigns[:on_restock]}
+    />
+    """
+  end
+
+  defp render_comp(%{comp: %{type: :unknown, assigns: %{raw: raw}}} = assigns) do
+    assigns = assign(assigns, :raw_json, Jason.encode!(raw, pretty: true))
+
+    ~H"""
+    <pre style="font-size:0.75rem;overflow:auto;">{@raw_json}</pre>
+    """
+  end
+
+  defp render_comp(assigns) do
+    _ = assigns
+    ~H""
+  end
+
+  # ── Detail panel (order / product / customer) ─────────────────────────────
+
+  attr :detail, :map, required: true
+
+  defp render_detail_panel(%{detail: %{type: :order, data: order}} = assigns) do
+    assigns = assign(assigns, :order, order)
+    ~H"<JargaAdminWeb.JargaComponents.order_detail order={@order} />"
+  end
+
+  defp render_detail_panel(%{detail: %{type: :product, data: product}} = assigns) do
+    assigns = assign(assigns, :product, product)
+    ~H"<JargaAdminWeb.JargaComponents.product_detail product={@product} />"
+  end
+
+  defp render_detail_panel(%{detail: %{type: :customer, data: customer}} = assigns) do
+    orders = MockData.orders()
+    recent = Enum.filter(orders, &(&1["customer_id"] == customer["id"]))
+    assigns = assigns |> assign(:customer, customer) |> assign(:recent_orders, recent)
+    ~H"<JargaAdminWeb.JargaComponents.customer_detail
+  customer={@customer}
+  recent_orders={@recent_orders}
+/>"
+  end
+
+  defp render_detail_panel(assigns) do
+    _ = assigns
+    ~H""
+  end
 
   # ──────────────────────────────────────────────────────────────────────────
   # Event handlers
@@ -376,6 +539,7 @@ defmodule JargaAdminWeb.ChatLive do
       |> assign(:typing, true)
       |> assign(:streaming_text, "")
       |> assign(:rendered_components, [])
+      |> assign(:detail, nil)
 
     # Send to Quecto (mock in dev)
     Task.start(fn ->
@@ -411,7 +575,8 @@ defmodule JargaAdminWeb.ChatLive do
      |> assign(:active_tab_id, tab_id)
      |> assign(:tabs, tabs)
      |> assign(:rendered_components, components)
-     |> assign(:context_menu, nil)}
+     |> assign(:context_menu, nil)
+     |> assign(:detail, nil)}
   end
 
   @impl true
@@ -536,6 +701,92 @@ defmodule JargaAdminWeb.ChatLive do
   @impl true
   def handle_event("cancel_form", _, socket) do
     {:noreply, assign(socket, :rendered_components, [])}
+  end
+
+  # ── Drill-through: Orders ──────────────────────────────────────────────────
+
+  @impl true
+  def handle_event("view_order", %{"id" => order_id}, socket) do
+    order = Enum.find(MockData.orders(), &(&1["id"] == order_id))
+
+    if order do
+      {:noreply, assign(socket, :detail, %{type: :order, data: order})}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  # ── Drill-through: Products ────────────────────────────────────────────────
+
+  @impl true
+  def handle_event("view_product", %{"id" => product_id}, socket) do
+    product = Enum.find(MockData.products(), &(&1["id"] == product_id))
+
+    if product do
+      {:noreply, assign(socket, :detail, %{type: :product, data: product})}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_event("edit_product", %{"id" => product_id}, socket) do
+    product = Enum.find(MockData.products(), &(&1["id"] == product_id))
+
+    if product do
+      {:noreply, assign(socket, :detail, %{type: :product, data: product})}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_event("duplicate_product", _params, socket) do
+    {:noreply, socket}
+  end
+
+  @impl true
+  def handle_event("archive_product", _params, socket) do
+    {:noreply, socket}
+  end
+
+  # ── Drill-through: Customers ───────────────────────────────────────────────
+
+  @impl true
+  def handle_event("view_customer", %{"id" => customer_id}, socket) do
+    customer = Enum.find(MockData.customers(), &(&1["id"] == customer_id))
+
+    if customer do
+      {:noreply, assign(socket, :detail, %{type: :customer, data: customer})}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  # ── Order actions ──────────────────────────────────────────────────────────
+
+  @impl true
+  def handle_event("fulfill_order", _params, socket) do
+    {:noreply, socket}
+  end
+
+  @impl true
+  def handle_event("refund_order", _params, socket) do
+    {:noreply, socket}
+  end
+
+  # ── Inventory ─────────────────────────────────────────────────────────────
+
+  @impl true
+  def handle_event("restock_item", _params, socket) do
+    {:noreply, socket}
+  end
+
+  # ── Clear detail panel ────────────────────────────────────────────────────
+
+  @impl true
+  def handle_event("clear_detail", _, socket) do
+    {:noreply, assign(socket, :detail, nil)}
   end
 
   # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Full Shopify-style admin UI with all components, clickable rows, and drill-through detail panels.

### New CSS classes
`j-stat-bar`, `j-breadcrumb`, `j-product-grid`, `j-product-card`, `j-detail-grid`, `j-line-items`, `j-totals`, `j-promo-card`, `j-kpi-row`, `j-inv-bar-wrap`, `j-action-bar`, `j-avatar`, `j-kv-list`, `j-section-header`

### New components (`jarga_components.ex`)
- `stat_bar` — horizontal headline numbers with deltas
- `breadcrumb` — clickable nav trail
- `action_bar` — action buttons + back button
- `product_grid` — responsive card grid with hover
- `order_detail` — full order view (line items, totals, timeline, customer, actions)
- `product_detail` — full product view (inventory bar, variants table, alerts)
- `customer_detail` — customer profile (KPIs, recent orders, segment badge)
- `promotion_list` — promo cards with use counts
- `inventory_table` — stock bar + restock action

### LiveView changes
- `detail` assign for drill-through (nil = list, {type, data} = detail panel)
- `render_comp` / `render_detail_panel` as proper HEEx sub-components
- Events: `view_order`, `view_product`, `view_customer`, `edit_product`, `fulfill_order`, `refund_order`, `restock_item`, `clear_detail`
- `data_table` gains `on_row_click` — click any row to drill through

### Default tabs
- 5 tabs: Dashboard · Orders · Products · Customers · Promotions
- Dashboard: stat bar + 7-day revenue chart + clickable orders + low-stock inventory
- Orders: stat bar + clickable orders table
- Products: stat bar + product grid
- Customers: stat bar + clickable customer table
- Promotions: stat bar + promotion cards

### Test status
51 tests, 0 failures · `mix format --check-formatted` clean

Closes #30 follow-up (feat/ui-elements)