### PR TITLE
feat: add storefront preview mode — banner and noindex tag

### DIFF
--- a/assets/css/storefront.css
+++ b/assets/css/storefront.css
@@ -1151,6 +1151,35 @@
   }
 }
 
+/* ── Preview Banner ────────────────────────────────────────── */
+
+.sf-preview-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 400;
+  background: #f59e0b;
+  color: #1a1a1a;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 6px 16px;
+  font-family: var(--sf-font-body, 'Helvetica Neue', sans-serif);
+  font-size: 0.7rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.sf-preview-banner-text {
+  font-weight: 600;
+}
+
+.sf-preview-banner-label {
+  opacity: 0.7;
+}
+
 /* ── Gallery Zoom ──────────────────────────────────────────── */
 
 .sf-gallery-zoom {

--- a/lib/jarga_admin_web/live/storefront_live.ex
+++ b/lib/jarga_admin_web/live/storefront_live.ex
@@ -78,6 +78,7 @@ defmodule JargaAdminWeb.StorefrontLive do
       |> assign(:og_description, "")
       |> assign(:og_image, nil)
       |> assign(:canonical_url, nil)
+      |> assign(:preview_mode, false)
       |> assign(:footer_columns, @footer_columns)
       |> assign(:footer_copyright, "© #{Date.utc_today().year} Jarga Commerce — Demo Store")
       |> assign(:theme_css_vars, "")
@@ -91,15 +92,20 @@ defmodule JargaAdminWeb.StorefrontLive do
   @impl true
   def handle_params(params, _uri, socket) do
     slug = resolve_slug(params)
+    preview = params["preview"] == "true"
 
     socket =
-      if slug != socket.assigns.slug do
-        socket
-        |> assign(:slug, slug)
-        |> load_page_data(slug)
-      else
-        socket
-      end
+      socket
+      |> assign(:preview_mode, preview)
+      |> then(fn s ->
+        if slug != s.assigns.slug do
+          s
+          |> assign(:slug, slug)
+          |> load_page_data(slug)
+        else
+          s
+        end
+      end)
 
     {:noreply, socket}
   end
@@ -301,6 +307,7 @@ defmodule JargaAdminWeb.StorefrontLive do
   @impl true
   def render(assigns) do
     ~H"""
+    <meta :if={@preview_mode} name="robots" content="noindex, nofollow" />
     <meta :if={@meta_description != ""} name="description" content={@meta_description} />
     <meta :if={@og_title != ""} property="og:title" content={@og_title} />
     <meta :if={@og_description != ""} property="og:description" content={@og_description} />
@@ -312,6 +319,10 @@ defmodule JargaAdminWeb.StorefrontLive do
       href={@theme_google_fonts_url}
     />
     <div class="sf-page" id="storefront-page" style={@theme_css_vars}>
+      <div :if={@preview_mode} id="preview-banner" class="sf-preview-banner">
+        <span class="sf-preview-banner-text">PREVIEW MODE</span>
+        <span class="sf-preview-banner-label">This page is not published</span>
+      </div>
       <StorefrontComponents.gallery_zoom
         gallery_zoom_open={@gallery_zoom_open}
         gallery_zoom_index={@gallery_zoom_index}

--- a/test/jarga_admin_web/live/storefront_live_test.exs
+++ b/test/jarga_admin_web/live/storefront_live_test.exs
@@ -429,6 +429,33 @@ defmodule JargaAdminWeb.StorefrontLiveTest do
     end
   end
 
+  describe "preview mode" do
+    test "shows preview banner when preview param is set", %{conn: conn, bypass: bypass} do
+      stub_storefront_api(bypass)
+
+      {:ok, view, html} = live(conn, "/store?preview=true")
+
+      assert has_element?(view, "#preview-banner")
+      assert html =~ "PREVIEW"
+    end
+
+    test "adds noindex meta tag in preview mode", %{conn: conn, bypass: bypass} do
+      stub_storefront_api(bypass)
+
+      {:ok, view, _html} = live(conn, "/store?preview=true")
+
+      assert has_element?(view, "meta[name=robots]")
+    end
+
+    test "does not show preview banner in normal mode", %{conn: conn, bypass: bypass} do
+      stub_storefront_api(bypass)
+
+      {:ok, view, _html} = live(conn, "/store")
+
+      refute has_element?(view, "#preview-banner")
+    end
+  end
+
   describe "SEO" do
     test "assigns meta_description from page spec", %{conn: conn, bypass: bypass} do
       stub_storefront_api(bypass)


### PR DESCRIPTION
Closes #85.

Adds preview mode to the storefront. When ?preview=true is present, shows an amber PREVIEW MODE banner and adds noindex meta tag.

## Tests
3 tests. 330 total, 20 pre-existing failures, 0 new.