### PR TITLE
feat: data-driven footer and nested navigation (#99)

### DIFF
--- a/assets/css/storefront.css
+++ b/assets/css/storefront.css
@@ -185,6 +185,52 @@
   transform-origin: left;
 }
 
+/* Nav dropdown */
+.sf-nav-dropdown {
+  position: relative;
+}
+
+.sf-nav-link-parent {
+  cursor: pointer;
+}
+
+.sf-nav-dropdown-panel {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--sf-color-nav-bg);
+  border: 1px solid var(--sf-color-border);
+  padding: var(--sf-space-sm) 0;
+  min-width: 180px;
+  z-index: 110;
+  margin-top: 8px;
+}
+
+.sf-nav-dropdown:hover .sf-nav-dropdown-panel {
+  display: block;
+}
+
+.sf-nav-dropdown-link {
+  display: block;
+  padding: 8px var(--sf-space-sm);
+  font-size: 11px;
+  font-weight: var(--sf-font-weight-regular);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--sf-color-text);
+  transition: background var(--sf-transition-speed) ease;
+}
+
+.sf-nav-dropdown-link:hover {
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.sf-nav-highlight {
+  color: var(--sf-color-accent);
+}
+
 .sf-nav-actions {
   display: flex;
   gap: var(--sf-space-sm);

--- a/lib/jarga_admin_web/components/storefront_components.ex
+++ b/lib/jarga_admin_web/components/storefront_components.ex
@@ -47,9 +47,34 @@ defmodule JargaAdminWeb.StorefrontComponents do
         <a href="/" class="sf-nav-logo">{@logo}</a>
 
         <div class="sf-nav-links">
-          <a :for={link <- @links} href={safe_href(link["href"])} class="sf-nav-link">
-            {link["label"]}
-          </a>
+          <%= for link <- @links do %>
+            <%= if link["children"] do %>
+              <div class="sf-nav-dropdown">
+                <span class={[
+                  "sf-nav-link sf-nav-link-parent",
+                  link["highlight"] && "sf-nav-highlight"
+                ]}>
+                  {link["label"]}
+                </span>
+                <div class="sf-nav-dropdown-panel">
+                  <a
+                    :for={child <- link["children"]}
+                    href={safe_href(child["href"])}
+                    class="sf-nav-dropdown-link"
+                  >
+                    {child["label"]}
+                  </a>
+                </div>
+              </div>
+            <% else %>
+              <a
+                href={safe_href(link["href"])}
+                class={["sf-nav-link", link["highlight"] && "sf-nav-highlight"]}
+              >
+                {link["label"]}
+              </a>
+            <% end %>
+          <% end %>
         </div>
 
         <div class="sf-nav-actions">

--- a/lib/jarga_admin_web/live/storefront_live.ex
+++ b/lib/jarga_admin_web/live/storefront_live.ex
@@ -17,7 +17,7 @@ defmodule JargaAdminWeb.StorefrontLive do
   alias JargaAdmin.StorefrontTheme
   alias JargaAdminWeb.StorefrontComponents
 
-  @footer_columns [
+  @default_footer_columns [
     %{
       "title" => "Shop",
       "links" => [
@@ -79,7 +79,7 @@ defmodule JargaAdminWeb.StorefrontLive do
       |> assign(:og_image, nil)
       |> assign(:canonical_url, nil)
       |> assign(:preview_mode, false)
-      |> assign(:footer_columns, @footer_columns)
+      |> assign(:footer_columns, @default_footer_columns)
       |> assign(:footer_copyright, "© #{Date.utc_today().year} Jarga Commerce — Demo Store")
       |> assign(:theme_css_vars, "")
       |> assign(:theme_google_fonts_url, nil)
@@ -531,16 +531,18 @@ defmodule JargaAdminWeb.StorefrontLive do
   defp load_page_data(socket, slug) do
     channel = socket.assigns[:channel_handle]
 
-    # Parallel fetch: page content + navigation + theme are independent
+    # Parallel fetch: page content + navigation + theme + footer are independent
     # TODO(multi-storefront): pass channel to page/nav API calls
     # when the backend supports per-channel content scoping
     page_task = Task.async(fn -> Api.get_storefront_page(slug) end)
     nav_task = Task.async(fn -> Api.get_storefront_navigation() end)
     theme_task = Task.async(fn -> StorefrontTheme.load(channel) end)
+    footer_task = Task.async(fn -> Api.get_storefront_slot("storefront_footer") end)
 
     page_result = Task.await(page_task, 10_000)
     nav_result = Task.await(nav_task, 10_000)
     theme_result = Task.await(theme_task, 10_000)
+    footer_result = Task.await(footer_task, 10_000)
 
     nav_links =
       case nav_result do
@@ -555,6 +557,9 @@ defmodule JargaAdminWeb.StorefrontLive do
       |> assign(:theme_css_vars, theme_result.css_vars)
       |> assign(:theme_google_fonts_url, theme_result.google_fonts_url)
       |> assign(:store_name, theme_result.store_name)
+
+    # Apply footer from API slot (falls back to hardcoded defaults)
+    socket = apply_footer_data(socket, footer_result)
 
     case page_result do
       {:ok, page} when is_map(page) ->
@@ -588,6 +593,17 @@ defmodule JargaAdminWeb.StorefrontLive do
         |> assign(:nav_links, nav_links)
     end
   end
+
+  defp apply_footer_data(socket, {:ok, %{"payload_json" => payload}}) when is_map(payload) do
+    columns = payload["columns"] || socket.assigns.footer_columns
+    copyright = payload["copyright"] || socket.assigns.footer_copyright
+
+    socket
+    |> assign(:footer_columns, columns)
+    |> assign(:footer_copyright, copyright)
+  end
+
+  defp apply_footer_data(socket, _), do: socket
 
   # content_json may be a JSON string (from the backend) or an already-decoded map (from tests)
   defp parse_content_json(json) when is_binary(json) do

--- a/test/jarga_admin_web/live/storefront_live_test.exs
+++ b/test/jarga_admin_web/live/storefront_live_test.exs
@@ -12,6 +12,14 @@ defmodule JargaAdminWeb.StorefrontLiveTest do
     JargaAdmin.StorefrontTheme.init_cache()
     JargaAdmin.StorefrontTheme.cache_clear()
 
+    # Default: footer slot returns 404 (falls back to hardcoded defaults)
+    # Tests that need a custom footer can override with their own stub.
+    Bypass.stub(bypass, "GET", "/v1/frontend/slots/storefront_footer", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(404, Jason.encode!(%{error: "not found"}))
+    end)
+
     {:ok, bypass: bypass}
   end
 
@@ -592,6 +600,111 @@ defmodule JargaAdminWeb.StorefrontLiveTest do
 
       render_click(view, "close_filters")
       refute has_element?(view, "#filter-drawer")
+    end
+  end
+
+  describe "data-driven footer" do
+    test "loads footer from API slot", %{conn: conn, bypass: bypass} do
+      footer_payload = %{
+        "columns" => [
+          %{
+            "title" => "Custom Shop",
+            "links" => [%{"label" => "Custom Link", "href" => "/custom"}]
+          }
+        ],
+        "copyright" => "© 2026 Custom Store"
+      }
+
+      Bypass.stub(bypass, "GET", "/v1/frontend/pages/home", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, homepage_spec())
+      end)
+
+      Bypass.stub(bypass, "GET", "/v1/frontend/navigation", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, navigation_spec())
+      end)
+
+      Bypass.stub(bypass, "GET", "/v1/frontend/slots/storefront_theme", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(404, Jason.encode!(%{error: "not found"}))
+      end)
+
+      Bypass.stub(bypass, "GET", "/v1/frontend/slots/storefront_footer", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(%{data: %{"payload_json" => footer_payload}}))
+      end)
+
+      {:ok, _view, html} = live(conn, "/store")
+
+      assert html =~ "Custom Shop"
+      assert html =~ "Custom Link"
+      assert html =~ "© 2026 Custom Store"
+    end
+
+    test "falls back to default footer when slot missing", %{conn: conn, bypass: bypass} do
+      stub_storefront_api(bypass)
+
+      {:ok, _view, html} = live(conn, "/store")
+
+      # Default footer should still render
+      assert html =~ "Bedroom"
+      assert html =~ "Jarga Commerce"
+    end
+  end
+
+  describe "nested navigation" do
+    test "renders nav links with children as dropdowns", %{conn: conn, bypass: bypass} do
+      nested_nav =
+        Jason.encode!(%{
+          data: %{
+            "items" => [
+              %{"label" => "BEDROOM", "href" => "/bedroom"},
+              %{
+                "label" => "LIVING",
+                "children" => [
+                  %{"label" => "Sofas", "href" => "/sofas"},
+                  %{"label" => "Tables", "href" => "/tables"}
+                ]
+              }
+            ]
+          }
+        })
+
+      Bypass.stub(bypass, "GET", "/v1/frontend/pages/home", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, homepage_spec())
+      end)
+
+      Bypass.stub(bypass, "GET", "/v1/frontend/navigation", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, nested_nav)
+      end)
+
+      Bypass.stub(bypass, "GET", "/v1/frontend/slots/storefront_theme", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(404, Jason.encode!(%{error: "not found"}))
+      end)
+
+      Bypass.stub(bypass, "GET", "/v1/frontend/slots/storefront_footer", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(404, Jason.encode!(%{error: "not found"}))
+      end)
+
+      {:ok, _view, html} = live(conn, "/store")
+
+      assert html =~ "BEDROOM"
+      assert html =~ "LIVING"
+      assert html =~ "Sofas"
+      assert html =~ "Tables"
     end
   end
 


### PR DESCRIPTION
Closes #99

## Changes
- Footer loaded from `storefront_footer` API slot in parallel with page/nav/theme
- Falls back to hardcoded defaults when slot unavailable
- Nav bar supports nested items with `children` array for dropdown menus
- Nav link `highlight` flag for accent-colored links (e.g. Sale)
- CSS for dropdown panels (hover-reveal, positioning)
- 5 new LiveView tests, all stubs updated for footer slot

Precommit: 395 tests, 20 pre-existing failures, 0 new