### PR TITLE
feat: flexible product listings (#100)

### DIFF
--- a/assets/css/storefront.css
+++ b/assets/css/storefront.css
@@ -486,9 +486,12 @@
   gap: var(--sf-space-sm);
 }
 
+.sf-grid-1 { grid-template-columns: 1fr; }
 .sf-grid-2 { grid-template-columns: repeat(2, 1fr); }
 .sf-grid-3 { grid-template-columns: repeat(3, 1fr); }
 .sf-grid-4 { grid-template-columns: repeat(4, 1fr); }
+.sf-grid-5 { grid-template-columns: repeat(5, 1fr); }
+.sf-grid-6 { grid-template-columns: repeat(6, 1fr); }
 
 /* ── Product Card ─────────────────────────────────────────────────────────── */
 .sf-product-card {
@@ -560,6 +563,77 @@
   font-size: 12px;
   font-weight: var(--sf-font-weight-regular);
   color: var(--sf-color-text-secondary);
+}
+
+/* Product badges */
+.sf-product-badge {
+  position: absolute;
+  top: var(--sf-space-sm);
+  left: var(--sf-space-sm);
+  background: var(--sf-color-accent);
+  color: var(--sf-color-btn-primary-text);
+  font-size: 10px;
+  font-weight: var(--sf-font-weight-medium);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 4px 8px;
+  z-index: 1;
+}
+
+/* Strikethrough pricing */
+.sf-product-card-price-was {
+  font-size: 12px;
+  color: var(--sf-color-text-muted);
+  text-decoration: line-through;
+  margin-right: 6px;
+}
+
+.sf-product-card-price-sale {
+  color: var(--sf-color-accent);
+}
+
+/* Card description (editorial variant) */
+.sf-product-card-description {
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--sf-color-text-secondary);
+  margin-top: 4px;
+}
+
+/* Editorial card variant — larger presentation */
+.sf-product-card.sf-card-editorial .sf-product-card-image-wrap {
+  aspect-ratio: 4 / 3;
+}
+
+.sf-product-card.sf-card-editorial .sf-product-card-name {
+  font-size: 14px;
+}
+
+/* Minimal card variant — image + name only */
+.sf-product-card.sf-card-minimal .sf-product-card-price,
+.sf-product-card.sf-card-minimal .sf-product-card-swatches {
+  display: none;
+}
+
+/* Detailed card variant — shows add-to-cart button */
+.sf-card-add-btn {
+  margin-top: 8px;
+  padding: 8px 16px;
+  background: var(--sf-color-btn-primary-bg);
+  color: var(--sf-color-btn-primary-text);
+  border: none;
+  font-family: var(--sf-font-primary);
+  font-size: 10px;
+  letter-spacing: var(--sf-letter-spacing-nav);
+  text-transform: uppercase;
+  cursor: pointer;
+  width: 100%;
+  border-radius: var(--sf-border-radius);
+  transition: opacity var(--sf-transition-speed) ease;
+}
+
+.sf-card-add-btn:hover {
+  opacity: 0.85;
 }
 
 .sf-product-card-swatches {

--- a/lib/jarga_admin/storefront_renderer.ex
+++ b/lib/jarga_admin/storefront_renderer.ex
@@ -226,10 +226,14 @@ defmodule JargaAdmin.StorefrontRenderer do
         id: p["id"],
         name: p["name"] || "",
         price: p["price"] || "",
+        compare_at_price: p["compare_at_price"],
         image_url: p["image_url"] || "",
         hover_image_url: p["hover_image_url"],
         href: p["href"] || "#",
         featured: p["featured"] == true,
+        variant: p["variant"] || "default",
+        badge: p["badge"],
+        description: p["description"],
         colours: p["colours"] || []
       }
     end)

--- a/lib/jarga_admin_web/components/storefront_components.ex
+++ b/lib/jarga_admin_web/components/storefront_components.ex
@@ -219,10 +219,26 @@ defmodule JargaAdminWeb.StorefrontComponents do
   attr :card_style, :string, default: ""
 
   def product_card(assigns) do
+    variant = assigns.product[:variant] || "default"
+
+    variant_class =
+      case variant do
+        "editorial" -> "sf-card-editorial"
+        "minimal" -> "sf-card-minimal"
+        "detailed" -> "sf-card-detailed"
+        _ -> nil
+      end
+
+    assigns = assign(assigns, :variant_class, variant_class)
+
     ~H"""
     <a
       href={safe_href(@product.href)}
-      class={["sf-product-card", @product.featured && "sf-featured"]}
+      class={[
+        "sf-product-card",
+        @product.featured && "sf-featured",
+        @variant_class
+      ]}
       style={@card_style}
     >
       <div
@@ -230,6 +246,7 @@ defmodule JargaAdminWeb.StorefrontComponents do
         id={"product-#{@product.id}"}
         data-has-hover={@product.hover_image_url && "true"}
       >
+        <span :if={@product[:badge]} class="sf-product-badge">{@product.badge}</span>
         <img
           src={@product.image_url}
           alt={@product.name}
@@ -246,7 +263,20 @@ defmodule JargaAdminWeb.StorefrontComponents do
       </div>
       <div class="sf-product-card-info">
         <span class="sf-product-card-name">{@product.name}</span>
-        <span class="sf-product-card-price">{@product.price}</span>
+        <div class="sf-product-card-price-row">
+          <span :if={@product[:compare_at_price]} class="sf-product-card-price-was">
+            {@product.compare_at_price}
+          </span>
+          <span class={[
+            "sf-product-card-price",
+            @product[:compare_at_price] && "sf-product-card-price-sale"
+          ]}>
+            {@product.price}
+          </span>
+        </div>
+        <p :if={@product[:description]} class="sf-product-card-description">
+          {@product.description}
+        </p>
         <div :if={@product[:colours] && @product.colours != []} class="sf-product-card-swatches">
           <span
             :for={colour <- Enum.take(@product.colours, 4)}
@@ -256,6 +286,17 @@ defmodule JargaAdminWeb.StorefrontComponents do
           >
           </span>
         </div>
+        <button
+          :if={(@product[:variant] || "default") == "detailed"}
+          class="sf-card-add-btn"
+          phx-click="add_to_cart"
+          phx-value-id={@product.id}
+          phx-value-name={@product.name}
+          phx-value-price={@product.price}
+          phx-value-image_url={@product.image_url}
+        >
+          ADD TO BASKET
+        </button>
       </div>
     </a>
     """
@@ -447,7 +488,14 @@ defmodule JargaAdminWeb.StorefrontComponents do
 
   # ── Sanitization helpers ──────────────────────────────────────────────────
 
-  @valid_grid_columns %{2 => "sf-grid-2", 3 => "sf-grid-3", 4 => "sf-grid-4"}
+  @valid_grid_columns %{
+    1 => "sf-grid-1",
+    2 => "sf-grid-2",
+    3 => "sf-grid-3",
+    4 => "sf-grid-4",
+    5 => "sf-grid-5",
+    6 => "sf-grid-6"
+  }
 
   @doc false
   def safe_grid_class(columns) when is_integer(columns) do

--- a/test/jarga_admin/storefront_renderer_test.exs
+++ b/test/jarga_admin/storefront_renderer_test.exs
@@ -422,6 +422,60 @@ defmodule JargaAdmin.StorefrontRendererTest do
       refute Map.has_key?(comp.assigns.style, "z_index")
     end
 
+    test "product normalisation passes through variant, badge, compare_at_price, description" do
+      spec = %{
+        "components" => [
+          %{
+            "type" => "product_grid",
+            "data" => %{
+              "columns" => 4,
+              "products" => [
+                %{
+                  "id" => "p1",
+                  "name" => "Linen Duvet",
+                  "price" => "£89.00",
+                  "compare_at_price" => "£129.00",
+                  "image_url" => "/img/duvet.jpg",
+                  "variant" => "editorial",
+                  "badge" => "SALE",
+                  "description" => "Stonewashed Belgian linen"
+                }
+              ]
+            }
+          }
+        ]
+      }
+
+      [comp] = StorefrontRenderer.render_spec(spec)
+      product = hd(comp.assigns.products)
+      assert product.variant == "editorial"
+      assert product.badge == "SALE"
+      assert product.compare_at_price == "£129.00"
+      assert product.description == "Stonewashed Belgian linen"
+    end
+
+    test "product defaults variant to default, badge to nil, compare_at_price to nil" do
+      spec = %{
+        "components" => [
+          %{
+            "type" => "product_grid",
+            "data" => %{
+              "products" => [
+                %{"id" => "p1", "name" => "Item", "price" => "£10", "image_url" => "/x.jpg"}
+              ]
+            }
+          }
+        ]
+      }
+
+      [comp] = StorefrontRenderer.render_spec(spec)
+      product = hd(comp.assigns.products)
+      assert product.variant == "default"
+      assert product.badge == nil
+      assert product.compare_at_price == nil
+      assert product.description == nil
+    end
+
     test "style works on all component types" do
       style = %{"background" => "#f0f0f0", "padding" => "40px"}
 


### PR DESCRIPTION
Closes #100

- Grid 1-6 columns (sf-grid-1/5/6 CSS)
- Card variants: editorial, minimal, detailed (variant class + conditional rendering)
- Product badges (NEW, SALE, -30%) — positioned overlay
- compare_at_price with strikethrough
- Description field for editorial cards
- Detailed variant inline add-to-cart button
- 2 new tests, precommit 397/20