### PR TITLE
feat: alternative PDP layouts (#101)

### DIFF
--- a/assets/css/storefront.css
+++ b/assets/css/storefront.css
@@ -738,6 +738,7 @@
 }
 
 /* ── Product Detail Page ──────────────────────────────────────────────────── */
+/* PDP base — default is gallery_sidebar */
 .sf-product-detail {
   display: grid;
   grid-template-columns: 1fr 400px;
@@ -745,6 +746,79 @@
   max-width: var(--sf-max-width);
   margin: 0 auto;
   padding: var(--sf-space-md);
+}
+
+/* PDP layout: gallery_sidebar (default — no override needed) */
+.sf-pdp-gallery-sidebar {
+  /* Uses base grid */
+}
+
+/* PDP layout: centered — single column, centered info */
+.sf-pdp-centered {
+  grid-template-columns: 1fr;
+  max-width: 800px;
+  text-align: center;
+}
+
+.sf-pdp-centered .sf-pdp-gallery {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.sf-pdp-centered .sf-pdp-info {
+  align-items: center;
+}
+
+/* PDP layout: full_width — edge-to-edge gallery, overlaid info */
+.sf-pdp-full-width {
+  grid-template-columns: 1fr;
+  max-width: 100%;
+  padding: 0;
+}
+
+.sf-pdp-full-width .sf-pdp-gallery {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2px;
+}
+
+.sf-pdp-full-width .sf-pdp-info {
+  max-width: var(--sf-max-width);
+  margin: 0 auto;
+  padding: var(--sf-space-lg) var(--sf-space-md);
+}
+
+/* PDP layout: split — 50/50 sticky sidebar */
+.sf-pdp-split {
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+}
+
+.sf-pdp-split .sf-pdp-info {
+  position: sticky;
+  top: var(--sf-nav-height);
+  align-self: start;
+  padding: var(--sf-space-lg);
+  height: calc(100vh - var(--sf-nav-height));
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+/* PDP layout: stacked — gallery row + info below */
+.sf-pdp-stacked {
+  grid-template-columns: 1fr;
+}
+
+.sf-pdp-stacked .sf-pdp-gallery {
+  flex-direction: row;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+}
+
+.sf-pdp-stacked .sf-pdp-gallery-image {
+  flex: 0 0 80%;
+  scroll-snap-align: start;
 }
 
 .sf-pdp-gallery {

--- a/lib/jarga_admin/storefront_renderer.ex
+++ b/lib/jarga_admin/storefront_renderer.ex
@@ -158,13 +158,18 @@ defmodule JargaAdmin.StorefrontRenderer do
     %{type: :product_grid, assigns: assigns}
   end
 
+  @valid_pdp_layouts ~w(gallery_sidebar centered full_width split stacked)
+
   defp normalize_component(%{"type" => "product_detail", "data" => data}) do
+    layout = if data["layout"] in @valid_pdp_layouts, do: data["layout"], else: "gallery_sidebar"
+
     %{
       type: :product_detail,
       assigns: %{
         id: data["id"],
         name: data["name"] || "",
         price: data["price"] || "",
+        layout: layout,
         images: data["images"] || [],
         description: data["description"],
         colours: data["colours"] || [],

--- a/lib/jarga_admin_web/components/storefront_components.ex
+++ b/lib/jarga_admin_web/components/storefront_components.ex
@@ -307,6 +307,7 @@ defmodule JargaAdminWeb.StorefrontComponents do
   attr :id, :string, default: nil
   attr :name, :string, required: true
   attr :price, :string, required: true
+  attr :layout, :string, default: "gallery_sidebar"
   attr :images, :list, default: []
   attr :description, :string, default: nil
   attr :colours, :list, default: []
@@ -314,14 +315,25 @@ defmodule JargaAdminWeb.StorefrontComponents do
   attr :accordion, :list, default: []
   attr :style, :map, default: %{}
 
+  @pdp_layout_classes %{
+    "gallery_sidebar" => "sf-pdp-gallery-sidebar",
+    "centered" => "sf-pdp-centered",
+    "full_width" => "sf-pdp-full-width",
+    "split" => "sf-pdp-split",
+    "stacked" => "sf-pdp-stacked"
+  }
+
   def product_detail(assigns) do
+    layout_class = Map.get(@pdp_layout_classes, assigns.layout, "sf-pdp-gallery-sidebar")
+
     assigns =
       assigns
       |> assign(:inline_style, StyleValidator.to_inline_style(assigns.style))
       |> assign(:title_style, StyleValidator.title_style(assigns.style))
+      |> assign(:layout_class, layout_class)
 
     ~H"""
-    <section class="sf-product-detail" id="sf-product-detail" style={@inline_style}>
+    <section class={["sf-product-detail", @layout_class]} id="sf-product-detail" style={@inline_style}>
       <div class="sf-pdp-gallery">
         <img
           :for={image <- @images}

--- a/lib/jarga_admin_web/live/storefront_live.ex
+++ b/lib/jarga_admin_web/live/storefront_live.ex
@@ -448,6 +448,7 @@ defmodule JargaAdminWeb.StorefrontLive do
       id={@a.id}
       name={@a.name}
       price={@a.price}
+      layout={@a.layout}
       images={@a.images}
       description={@a.description}
       colours={@a.colours}

--- a/test/jarga_admin/storefront_renderer_test.exs
+++ b/test/jarga_admin/storefront_renderer_test.exs
@@ -454,6 +454,38 @@ defmodule JargaAdmin.StorefrontRendererTest do
       assert product.description == "Stonewashed Belgian linen"
     end
 
+    test "product_detail passes through layout field" do
+      spec = %{
+        "components" => [
+          %{
+            "type" => "product_detail",
+            "data" => %{
+              "name" => "Candle",
+              "price" => "£32.00",
+              "layout" => "centered"
+            }
+          }
+        ]
+      }
+
+      [comp] = StorefrontRenderer.render_spec(spec)
+      assert comp.assigns.layout == "centered"
+    end
+
+    test "product_detail defaults layout to gallery_sidebar" do
+      spec = %{
+        "components" => [
+          %{
+            "type" => "product_detail",
+            "data" => %{"name" => "Item", "price" => "£10"}
+          }
+        ]
+      }
+
+      [comp] = StorefrontRenderer.render_spec(spec)
+      assert comp.assigns.layout == "gallery_sidebar"
+    end
+
     test "product defaults variant to default, badge to nil, compare_at_price to nil" do
       spec = %{
         "components" => [


### PR DESCRIPTION
Closes #101

## Changes
- `layout` field on product_detail: `gallery_sidebar` (default), `centered`, `full_width`, `split`, `stacked`
- Allowlist validation in StorefrontRenderer — invalid layouts fall back to gallery_sidebar
- CSS layout variants with distinct grid/flex arrangements
- Layout class applied to `.sf-product-detail` section
- 2 new renderer tests

Precommit: 399 tests, 20 pre-existing failures, 0 new