### PR TITLE
feat: data-driven filter drawer (#102)

### DIFF
--- a/assets/css/storefront.css
+++ b/assets/css/storefront.css
@@ -1530,6 +1530,159 @@
   letter-spacing: 0.05em;
 }
 
+/* Filter facets */
+.sf-filter-facet {
+  padding-bottom: var(--sf-space-md);
+  margin-bottom: var(--sf-space-md);
+  border-bottom: 1px solid var(--sf-color-border);
+}
+
+.sf-filter-facet:last-child {
+  border-bottom: none;
+}
+
+.sf-filter-facet-title {
+  font-family: var(--sf-font-primary);
+  font-size: 11px;
+  font-weight: var(--sf-font-weight-medium);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  margin: 0 0 var(--sf-space-sm) 0;
+  display: block;
+}
+
+/* Checkbox facet */
+.sf-filter-checkbox-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sf-filter-checkbox-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 0;
+  font-family: var(--sf-font-body);
+  font-size: 13px;
+  color: var(--sf-color-text);
+  text-align: left;
+}
+
+.sf-filter-check-box {
+  width: 16px;
+  height: 16px;
+  border: 1px solid var(--sf-color-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: all var(--sf-transition-speed) ease;
+}
+
+.sf-filter-check-box.sf-checked {
+  background: var(--sf-color-text);
+  border-color: var(--sf-color-text);
+}
+
+.sf-filter-check-box.sf-checked::after {
+  content: '✓';
+  color: var(--sf-color-bg);
+  font-size: 10px;
+}
+
+/* Swatch facet */
+.sf-filter-swatch-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.sf-filter-swatch {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+}
+
+.sf-filter-swatch-circle {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  transition: border-color var(--sf-transition-speed) ease;
+}
+
+.sf-filter-swatch.sf-filter-active .sf-filter-swatch-circle {
+  border-color: var(--sf-color-text);
+}
+
+.sf-filter-swatch-label {
+  font-size: 10px;
+  color: var(--sf-color-text-muted);
+  letter-spacing: 0.05em;
+}
+
+/* Range facet */
+.sf-filter-range {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sf-filter-range-label {
+  font-size: 13px;
+  color: var(--sf-color-text);
+}
+
+.sf-filter-range-sep {
+  color: var(--sf-color-text-muted);
+}
+
+/* Toggle facet */
+.sf-filter-toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.sf-filter-toggle {
+  width: 40px;
+  height: 22px;
+  border-radius: 11px;
+  background: var(--sf-color-border);
+  border: none;
+  cursor: pointer;
+  position: relative;
+  transition: background var(--sf-transition-speed) ease;
+}
+
+.sf-filter-toggle.sf-filter-active {
+  background: var(--sf-color-text);
+}
+
+.sf-filter-toggle-knob {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: white;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform var(--sf-transition-speed) ease;
+}
+
+.sf-filter-toggle.sf-filter-active .sf-filter-toggle-knob {
+  transform: translateX(18px);
+}
+
 .sf-filter-footer {
   padding: var(--sf-space-md, 24px);
   border-top: 1px solid var(--sf-color-border, rgba(0,0,0,0.08));

--- a/lib/jarga_admin/storefront_renderer.ex
+++ b/lib/jarga_admin/storefront_renderer.ex
@@ -39,6 +39,65 @@ defmodule JargaAdmin.StorefrontRenderer do
 
   def render_spec(_), do: []
 
+  @valid_filter_types ~w(checkbox swatch range toggle)
+
+  @doc "Extract and normalize filter facets from page spec."
+  def extract_filters(%{"filters" => filters}) when is_list(filters) do
+    filters
+    |> Enum.filter(fn f -> is_map(f) and f["type"] in @valid_filter_types end)
+    |> Enum.map(&normalize_filter/1)
+  end
+
+  def extract_filters(_), do: []
+
+  defp normalize_filter(%{"type" => "checkbox"} = f) do
+    %{
+      type: "checkbox",
+      key: f["key"] || "",
+      label: f["label"] || "",
+      options: normalize_filter_options(f["options"])
+    }
+  end
+
+  defp normalize_filter(%{"type" => "swatch"} = f) do
+    %{
+      type: "swatch",
+      key: f["key"] || "",
+      label: f["label"] || "",
+      options:
+        (f["options"] || [])
+        |> Enum.map(fn o ->
+          %{value: o["value"] || "", label: o["label"] || "", hex: o["hex"] || "#000000"}
+        end)
+    }
+  end
+
+  defp normalize_filter(%{"type" => "range"} = f) do
+    %{
+      type: "range",
+      key: f["key"] || "",
+      label: f["label"] || "",
+      min: f["min"] || 0,
+      max: f["max"] || 1000,
+      step: f["step"] || 1,
+      currency: f["currency"] || ""
+    }
+  end
+
+  defp normalize_filter(%{"type" => "toggle"} = f) do
+    %{
+      type: "toggle",
+      key: f["key"] || "",
+      label: f["label"] || ""
+    }
+  end
+
+  defp normalize_filter_options(nil), do: []
+
+  defp normalize_filter_options(options) when is_list(options) do
+    Enum.map(options, fn o -> %{value: o["value"] || "", label: o["label"] || ""} end)
+  end
+
   # ── Editorial / Layout ──────────────────────────────────────────────────
 
   defp normalize_component(%{"type" => "editorial_hero", "data" => data}) do

--- a/lib/jarga_admin_web/components/storefront_components.ex
+++ b/lib/jarga_admin_web/components/storefront_components.ex
@@ -640,6 +640,7 @@ defmodule JargaAdminWeb.StorefrontComponents do
 
   attr :filters_open, :boolean, default: false
   attr :active_filters, :map, default: %{}
+  attr :filter_config, :list, default: []
 
   def filter_drawer(assigns) do
     ~H"""
@@ -669,13 +670,116 @@ defmodule JargaAdminWeb.StorefrontComponents do
         </div>
 
         <div class="sf-filter-body">
-          <p class="sf-filter-empty">Filter configuration is agent-managed.</p>
+          <%= if @filter_config == [] do %>
+            <p class="sf-filter-empty">No filters available.</p>
+          <% else %>
+            <%= for facet <- @filter_config do %>
+              <.filter_facet facet={facet} active_filters={@active_filters} />
+            <% end %>
+          <% end %>
         </div>
 
         <div class="sf-filter-footer">
           <button class="sf-filter-clear" phx-click="clear_filters">CLEAR ALL</button>
         </div>
       </div>
+    </div>
+    """
+  end
+
+  attr :facet, :map, required: true
+  attr :active_filters, :map, default: %{}
+
+  defp filter_facet(%{facet: %{type: "checkbox"}} = assigns) do
+    active_values = Map.get(assigns.active_filters, assigns.facet.key, [])
+    assigns = assign(assigns, :active_values, active_values)
+
+    ~H"""
+    <div class="sf-filter-facet" id={"filter-facet-#{@facet.key}"}>
+      <h4 class="sf-filter-facet-title">{@facet.label}</h4>
+      <div class="sf-filter-checkbox-list">
+        <%= for opt <- @facet.options do %>
+          <button
+            id={"filter-checkbox-#{@facet.key}-#{opt.value}"}
+            class={["sf-filter-checkbox-item", opt.value in @active_values && "sf-filter-active"]}
+            phx-click="apply_filter"
+            phx-value-key={@facet.key}
+            phx-value-value={opt.value}
+          >
+            <span class={["sf-filter-check-box", opt.value in @active_values && "sf-checked"]}></span>
+            <span class="sf-filter-check-label">{opt.label}</span>
+          </button>
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+
+  defp filter_facet(%{facet: %{type: "swatch"}} = assigns) do
+    active_values = Map.get(assigns.active_filters, assigns.facet.key, [])
+    assigns = assign(assigns, :active_values, active_values)
+
+    ~H"""
+    <div class="sf-filter-facet" id={"filter-facet-#{@facet.key}"}>
+      <h4 class="sf-filter-facet-title">{@facet.label}</h4>
+      <div class="sf-filter-swatch-list">
+        <%= for opt <- @facet.options do %>
+          <button
+            id={"filter-swatch-#{@facet.key}-#{opt.value}"}
+            class={["sf-filter-swatch", opt.value in @active_values && "sf-filter-active"]}
+            phx-click="apply_filter"
+            phx-value-key={@facet.key}
+            phx-value-value={opt.value}
+            title={opt.label}
+          >
+            <span class="sf-filter-swatch-circle" style={"background-color: #{sanitize_hex(opt.hex)}"}>
+            </span>
+            <span class="sf-filter-swatch-label">{opt.label}</span>
+          </button>
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+
+  defp filter_facet(%{facet: %{type: "range"}} = assigns) do
+    ~H"""
+    <div class="sf-filter-facet" id={"filter-facet-#{@facet.key}"}>
+      <h4 class="sf-filter-facet-title">{@facet.label}</h4>
+      <div class="sf-filter-range">
+        <span class="sf-filter-range-label">{@facet.currency}{@facet.min}</span>
+        <span class="sf-filter-range-sep">—</span>
+        <span class="sf-filter-range-label">{@facet.currency}{@facet.max}</span>
+      </div>
+    </div>
+    """
+  end
+
+  defp filter_facet(%{facet: %{type: "toggle"}} = assigns) do
+    active = Map.has_key?(assigns.active_filters, assigns.facet.key)
+    assigns = assign(assigns, :active, active)
+
+    ~H"""
+    <div class="sf-filter-facet" id={"filter-facet-#{@facet.key}"}>
+      <div class="sf-filter-toggle-row">
+        <span class="sf-filter-facet-title">{@facet.label}</span>
+        <button
+          class={["sf-filter-toggle", @active && "sf-filter-active"]}
+          phx-click="apply_filter"
+          phx-value-key={@facet.key}
+          phx-value-value="true"
+        >
+          <span class="sf-filter-toggle-knob"></span>
+        </button>
+      </div>
+    </div>
+    """
+  end
+
+  defp filter_facet(assigns) do
+    ~H"""
+    <div class="sf-filter-facet">
+      <p class="sf-filter-empty">Unknown filter type</p>
     </div>
     """
   end

--- a/lib/jarga_admin_web/live/storefront_live.ex
+++ b/lib/jarga_admin_web/live/storefront_live.ex
@@ -70,6 +70,7 @@ defmodule JargaAdminWeb.StorefrontLive do
       |> assign(:search_ref, nil)
       |> assign(:filters_open, false)
       |> assign(:active_filters, %{})
+      |> assign(:filter_config, [])
       |> assign(:gallery_zoom_open, false)
       |> assign(:gallery_zoom_index, 0)
       |> assign(:gallery_zoom_images, [])
@@ -145,6 +146,31 @@ defmodule JargaAdminWeb.StorefrontLive do
   end
 
   @impl true
+  def handle_event("apply_filter", %{"key" => key, "value" => value}, socket) do
+    active = socket.assigns.active_filters
+    current = Map.get(active, key, [])
+
+    updated =
+      if value in current do
+        List.delete(current, value)
+      else
+        [value | current]
+      end
+
+    new_filters =
+      if updated == [] do
+        Map.delete(active, key)
+      else
+        Map.put(active, key, updated)
+      end
+
+    {:noreply, assign(socket, :active_filters, new_filters)}
+  end
+
+  def handle_event("remove_filter", %{"key" => key}, socket) do
+    {:noreply, assign(socket, :active_filters, Map.delete(socket.assigns.active_filters, key))}
+  end
+
   def handle_event("clear_filters", _params, socket) do
     {:noreply,
      socket
@@ -331,6 +357,7 @@ defmodule JargaAdminWeb.StorefrontLive do
       <StorefrontComponents.filter_drawer
         filters_open={@filters_open}
         active_filters={@active_filters}
+        filter_config={@filter_config}
       />
       <StorefrontComponents.search_overlay
         search_open={@search_open}
@@ -578,6 +605,8 @@ defmodule JargaAdminWeb.StorefrontLive do
         |> assign(:og_image, sanitize_cart_image_url(seo["og_image"]))
         |> assign(:canonical_url, sanitize_cart_image_url(seo["canonical"]))
         |> assign(:components, components)
+        |> assign(:filter_config, StorefrontRenderer.extract_filters(content_json))
+        |> assign(:active_filters, %{})
         |> assign(:nav_links, nav_links)
         |> assign(:error, nil)
 

--- a/test/jarga_admin/storefront_renderer_test.exs
+++ b/test/jarga_admin/storefront_renderer_test.exs
@@ -454,6 +454,58 @@ defmodule JargaAdmin.StorefrontRendererTest do
       assert product.description == "Stonewashed Belgian linen"
     end
 
+    test "extracts filters from content_json" do
+      spec = %{
+        "filters" => [
+          %{
+            "key" => "category",
+            "label" => "Category",
+            "type" => "checkbox",
+            "options" => [%{"value" => "bedding", "label" => "Bedding"}]
+          },
+          %{
+            "key" => "colour",
+            "label" => "Colour",
+            "type" => "swatch",
+            "options" => [%{"value" => "white", "label" => "White", "hex" => "#ffffff"}]
+          },
+          %{
+            "key" => "price",
+            "label" => "Price",
+            "type" => "range",
+            "min" => 0,
+            "max" => 500,
+            "step" => 10,
+            "currency" => "£"
+          },
+          %{
+            "key" => "in_stock",
+            "label" => "In Stock Only",
+            "type" => "toggle"
+          }
+        ],
+        "components" => []
+      }
+
+      filters = StorefrontRenderer.extract_filters(spec)
+      assert length(filters) == 4
+      [checkbox, swatch, range, toggle] = filters
+      assert checkbox.type == "checkbox"
+      assert checkbox.key == "category"
+      assert length(checkbox.options) == 1
+      assert swatch.type == "swatch"
+      assert hd(swatch.options).hex == "#ffffff"
+      assert range.type == "range"
+      assert range.min == 0
+      assert range.max == 500
+      assert toggle.type == "toggle"
+    end
+
+    test "extract_filters returns empty list when no filters" do
+      spec = %{"components" => []}
+      assert StorefrontRenderer.extract_filters(spec) == []
+    end
+
     test "product_detail passes through layout field" do
       spec = %{
         "components" => [

--- a/test/jarga_admin_web/live/storefront_live_test.exs
+++ b/test/jarga_admin_web/live/storefront_live_test.exs
@@ -601,6 +601,171 @@ defmodule JargaAdminWeb.StorefrontLiveTest do
       render_click(view, "close_filters")
       refute has_element?(view, "#filter-drawer")
     end
+
+    test "renders checkbox facets from page spec filters", %{conn: conn, bypass: bypass} do
+      page_with_filters =
+        Jason.encode!(%{
+          data: %{
+            "id" => "pg_test",
+            "slug" => "home",
+            "title" => "Filtered Page",
+            "content_json" => %{
+              "filters" => [
+                %{
+                  "key" => "category",
+                  "label" => "Category",
+                  "type" => "checkbox",
+                  "options" => [
+                    %{"value" => "bedding", "label" => "Bedding"},
+                    %{"value" => "throws", "label" => "Throws"}
+                  ]
+                }
+              ],
+              "components" => [
+                %{
+                  "type" => "text_block",
+                  "data" => %{"heading" => "Test", "body" => "content"}
+                }
+              ]
+            }
+          }
+        })
+
+      Bypass.stub(bypass, "GET", "/v1/frontend/pages/home", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, page_with_filters)
+      end)
+
+      Bypass.stub(bypass, "GET", "/v1/frontend/navigation", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, navigation_spec())
+      end)
+
+      Bypass.stub(bypass, "GET", "/v1/frontend/slots/storefront_theme", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(404, Jason.encode!(%{error: "not found"}))
+      end)
+
+      {:ok, view, _html} = live(conn, "/store")
+
+      render_click(view, "toggle_filters")
+      assert has_element?(view, "#filter-drawer")
+      assert has_element?(view, "#filter-facet-category")
+      assert has_element?(view, "#filter-checkbox-category-bedding")
+      assert has_element?(view, "#filter-checkbox-category-throws")
+    end
+
+    test "renders swatch facets with colour circles", %{conn: conn, bypass: bypass} do
+      page_with_swatches =
+        Jason.encode!(%{
+          data: %{
+            "id" => "pg_test",
+            "slug" => "home",
+            "title" => "Swatch Page",
+            "content_json" => %{
+              "filters" => [
+                %{
+                  "key" => "colour",
+                  "label" => "Colour",
+                  "type" => "swatch",
+                  "options" => [
+                    %{"value" => "white", "label" => "White", "hex" => "#ffffff"},
+                    %{"value" => "grey", "label" => "Grey", "hex" => "#999999"}
+                  ]
+                }
+              ],
+              "components" => [
+                %{"type" => "text_block", "data" => %{"heading" => "T", "body" => "c"}}
+              ]
+            }
+          }
+        })
+
+      Bypass.stub(bypass, "GET", "/v1/frontend/pages/home", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, page_with_swatches)
+      end)
+
+      Bypass.stub(bypass, "GET", "/v1/frontend/navigation", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, navigation_spec())
+      end)
+
+      Bypass.stub(bypass, "GET", "/v1/frontend/slots/storefront_theme", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(404, Jason.encode!(%{error: "not found"}))
+      end)
+
+      {:ok, view, _html} = live(conn, "/store")
+
+      render_click(view, "toggle_filters")
+      assert has_element?(view, "#filter-facet-colour")
+      assert has_element?(view, "#filter-swatch-colour-white")
+    end
+
+    test "apply_filter event updates active filters", %{conn: conn, bypass: bypass} do
+      page_with_filters =
+        Jason.encode!(%{
+          data: %{
+            "id" => "pg_test",
+            "slug" => "home",
+            "title" => "Filter Page",
+            "content_json" => %{
+              "filters" => [
+                %{
+                  "key" => "category",
+                  "label" => "Category",
+                  "type" => "checkbox",
+                  "options" => [%{"value" => "bedding", "label" => "Bedding"}]
+                }
+              ],
+              "components" => [
+                %{"type" => "text_block", "data" => %{"heading" => "T", "body" => "c"}}
+              ]
+            }
+          }
+        })
+
+      Bypass.stub(bypass, "GET", "/v1/frontend/pages/home", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, page_with_filters)
+      end)
+
+      Bypass.stub(bypass, "GET", "/v1/frontend/navigation", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, navigation_spec())
+      end)
+
+      Bypass.stub(bypass, "GET", "/v1/frontend/slots/storefront_theme", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(404, Jason.encode!(%{error: "not found"}))
+      end)
+
+      {:ok, view, _html} = live(conn, "/store")
+
+      render_click(view, "toggle_filters")
+      render_click(view, "apply_filter", %{"key" => "category", "value" => "bedding"})
+
+      # Filter should be active — checkbox should show checked state
+      assert has_element?(view, "#filter-checkbox-category-bedding.sf-filter-active")
+    end
+
+    test "no filters shows empty state", %{conn: conn, bypass: bypass} do
+      stub_storefront_api(bypass)
+
+      {:ok, view, _html} = live(conn, "/store")
+      render_click(view, "toggle_filters")
+      assert has_element?(view, ".sf-filter-empty")
+    end
   end
 
   describe "data-driven footer" do


### PR DESCRIPTION
Closes #102

## Changes
- `StorefrontRenderer.extract_filters/1` — parse/normalize filter facets from page spec `filters` array
- 4 filter types: checkbox, swatch, range, toggle
- `apply_filter`/`remove_filter`/`clear_filters` event handlers in StorefrontLive
- Dynamic facet rendering in filter_drawer component
- Active state tracking per facet key (toggle on/off)
- Full CSS for all facet types
- 7 new tests

Precommit: 405 tests, 20 pre-existing failures, 0 new