### PR TITLE
feat: hydration sort/filter and parallel fetch (#106)

### DIFF
--- a/lib/jarga_admin/storefront_hydrator.ex
+++ b/lib/jarga_admin/storefront_hydrator.ex
@@ -19,6 +19,7 @@ defmodule JargaAdmin.StorefrontHydrator do
   require Logger
 
   @hydratable_types [:product_grid, :product_scroll, :related_products]
+  @valid_sorts ~w(created_at:desc created_at:asc price:asc price:desc name:asc name:desc featured)
 
   @doc "Returns true if the component has a data source that needs hydration."
   def needs_hydration?(%{type: type, assigns: %{source: source}})
@@ -29,35 +30,78 @@ defmodule JargaAdmin.StorefrontHydrator do
   def needs_hydration?(_), do: false
 
   @doc "Builds API query params from the component's source configuration."
-  def build_api_params(%{source: "newest"} = assigns) do
-    %{
-      "sort" => "created_at:desc",
-      "limit" => to_string(assigns[:limit] || 12)
-    }
-  end
+  def build_api_params(%{source: source} = assigns) do
+    base =
+      case source do
+        "newest" -> %{"sort" => "created_at:desc"}
+        "featured" -> %{"featured" => "true"}
+        "collection" -> %{"collection_id" => assigns[:collection_id]}
+        "category" -> %{"category" => assigns[:category_slug]}
+        _ -> nil
+      end
 
-  def build_api_params(%{source: "featured"} = assigns) do
-    %{
-      "featured" => "true",
-      "limit" => to_string(assigns[:limit] || 12)
-    }
-  end
-
-  def build_api_params(%{source: "collection", collection_id: id} = assigns) do
-    %{
-      "collection_id" => id,
-      "limit" => to_string(assigns[:limit] || 12)
-    }
-  end
-
-  def build_api_params(%{source: "category", category_slug: slug} = assigns) do
-    %{
-      "category" => slug,
-      "limit" => to_string(assigns[:limit] || 12)
-    }
+    if base do
+      base
+      |> Map.put("limit", to_string(assigns[:limit] || 12))
+      |> maybe_put_offset(assigns)
+      |> maybe_put_sort(assigns, source)
+      |> apply_filters(assigns)
+    else
+      %{}
+    end
   end
 
   def build_api_params(_), do: %{}
+
+  defp maybe_put_offset(params, %{offset: offset}) when is_integer(offset) and offset > 0 do
+    Map.put(params, "offset", to_string(offset))
+  end
+
+  defp maybe_put_offset(params, _), do: params
+
+  defp maybe_put_sort(params, %{sort: sort}, _source) when is_binary(sort) do
+    if sort in @valid_sorts, do: Map.put(params, "sort", sort), else: params
+  end
+
+  defp maybe_put_sort(params, _, _source), do: params
+
+  defp apply_filters(params, %{filters: filters}) when is_map(filters) do
+    params
+    |> maybe_put_price(filters, "price_min")
+    |> maybe_put_price(filters, "price_max")
+    |> maybe_put_tags(filters)
+    |> maybe_put_in_stock(filters)
+    |> maybe_put_exclude(filters)
+  end
+
+  defp apply_filters(params, _), do: params
+
+  defp maybe_put_price(params, filters, key) do
+    case filters[key] do
+      val when is_number(val) and val >= 0 -> Map.put(params, key, to_string(val))
+      _ -> params
+    end
+  end
+
+  defp maybe_put_tags(params, %{"tags" => tags}) when is_list(tags) and tags != [] do
+    safe_tags = tags |> Enum.filter(&is_binary/1) |> Enum.join(",")
+    if safe_tags != "", do: Map.put(params, "tags", safe_tags), else: params
+  end
+
+  defp maybe_put_tags(params, _), do: params
+
+  defp maybe_put_in_stock(params, %{"in_stock" => true}) do
+    Map.put(params, "in_stock", "true")
+  end
+
+  defp maybe_put_in_stock(params, _), do: params
+
+  defp maybe_put_exclude(params, %{"exclude_ids" => ids}) when is_list(ids) and ids != [] do
+    safe_ids = ids |> Enum.filter(&is_binary/1) |> Enum.join(",")
+    if safe_ids != "", do: Map.put(params, "exclude", safe_ids), else: params
+  end
+
+  defp maybe_put_exclude(params, _), do: params
 
   @doc """
   Hydrates a single component with live product data.
@@ -71,7 +115,6 @@ defmodule JargaAdmin.StorefrontHydrator do
     if params == %{} do
       component
     else
-      # TODO: batch/parallelize hydration when multiple components need data
       products =
         case Api.list_products(params) do
           {:ok, products} when is_list(products) ->
@@ -93,15 +136,25 @@ defmodule JargaAdmin.StorefrontHydrator do
   Hydrates all components in a list that need hydration.
 
   Components without a source field are passed through unchanged.
+  Uses parallel fetching for multiple hydratable components.
   """
   def hydrate_all(components) when is_list(components) do
-    Enum.map(components, fn component ->
-      if needs_hydration?(component) do
-        hydrate(component)
-      else
-        component
-      end
-    end)
+    indexed = Enum.with_index(components)
+
+    {to_hydrate, pass_through} =
+      Enum.split_with(indexed, fn {comp, _idx} -> needs_hydration?(comp) end)
+
+    hydrated =
+      to_hydrate
+      |> Task.async_stream(
+        fn {comp, idx} -> {hydrate(comp), idx} end,
+        max_concurrency: 4,
+        timeout: 10_000
+      )
+      |> Enum.map(fn {:ok, result} -> result end)
+
+    all = hydrated ++ Enum.map(pass_through, fn {comp, idx} -> {comp, idx} end)
+    all |> Enum.sort_by(&elem(&1, 1)) |> Enum.map(&elem(&1, 0))
   end
 
   def hydrate_all(other), do: other

--- a/lib/jarga_admin/storefront_renderer.ex
+++ b/lib/jarga_admin/storefront_renderer.ex
@@ -278,6 +278,9 @@ defmodule JargaAdmin.StorefrontRenderer do
     assigns
     |> Map.put(:source, source)
     |> Map.put(:limit, data["limit"])
+    |> Map.put(:offset, data["offset"])
+    |> Map.put(:sort, data["sort"])
+    |> Map.put(:filters, data["filters"])
     |> Map.put(:collection_id, data["collection_id"])
     |> Map.put(:category_slug, data["category_slug"])
   end

--- a/test/jarga_admin/storefront_hydrator_test.exs
+++ b/test/jarga_admin/storefront_hydrator_test.exs
@@ -66,5 +66,108 @@ defmodule JargaAdmin.StorefrontHydratorTest do
 
       assert params["limit"] == "12"
     end
+
+    test "includes sort param when provided" do
+      assigns = %{source: "category", category_slug: "bedroom", sort: "price:asc"}
+
+      params = StorefrontHydrator.build_api_params(assigns)
+
+      assert params["sort"] == "price:asc"
+      assert params["category"] == "bedroom"
+    end
+
+    test "rejects invalid sort value and uses default" do
+      assigns = %{source: "newest", sort: "invalid:sort"}
+
+      params = StorefrontHydrator.build_api_params(assigns)
+
+      # Should fall back to the source default sort
+      assert params["sort"] == "created_at:desc"
+    end
+
+    test "includes price filter params" do
+      assigns = %{
+        source: "category",
+        category_slug: "bedroom",
+        filters: %{"price_min" => 20, "price_max" => 100}
+      }
+
+      params = StorefrontHydrator.build_api_params(assigns)
+
+      assert params["price_min"] == "20"
+      assert params["price_max"] == "100"
+    end
+
+    test "includes tag filter params" do
+      assigns = %{
+        source: "category",
+        category_slug: "bedroom",
+        filters: %{"tags" => ["organic", "linen"]}
+      }
+
+      params = StorefrontHydrator.build_api_params(assigns)
+
+      assert params["tags"] == "organic,linen"
+    end
+
+    test "includes in_stock filter" do
+      assigns = %{
+        source: "category",
+        category_slug: "bedroom",
+        filters: %{"in_stock" => true}
+      }
+
+      params = StorefrontHydrator.build_api_params(assigns)
+
+      assert params["in_stock"] == "true"
+    end
+
+    test "includes exclude_ids filter" do
+      assigns = %{
+        source: "newest",
+        filters: %{"exclude_ids" => ["prod_123", "prod_456"]}
+      }
+
+      params = StorefrontHydrator.build_api_params(assigns)
+
+      assert params["exclude"] == "prod_123,prod_456"
+    end
+
+    test "rejects negative price values" do
+      assigns = %{
+        source: "newest",
+        filters: %{"price_min" => -10, "price_max" => 100}
+      }
+
+      params = StorefrontHydrator.build_api_params(assigns)
+
+      refute Map.has_key?(params, "price_min")
+      assert params["price_max"] == "100"
+    end
+
+    test "includes offset param" do
+      assigns = %{source: "newest", offset: 24}
+
+      params = StorefrontHydrator.build_api_params(assigns)
+
+      assert params["offset"] == "24"
+    end
+  end
+
+  describe "hydrate_all/1 ordering" do
+    test "preserves component order with non-hydratable components" do
+      components = [
+        %{type: :editorial_hero, assigns: %{title: "Hero"}},
+        %{type: :text_block, assigns: %{heading: "Text"}},
+        %{type: :category_nav, assigns: %{categories: []}}
+      ]
+
+      result = StorefrontHydrator.hydrate_all(components)
+
+      assert length(result) == 3
+      assert Enum.at(result, 0).type == :editorial_hero
+      assert Enum.at(result, 1).type == :text_block
+      assert Enum.at(result, 2).type == :category_nav
+    end
   end
 end


### PR DESCRIPTION
Closes #106

## Changes
- Extended `build_api_params/1`: sort (7 validated options), price_min/max, tags, in_stock, exclude_ids, offset
- Sort validated against allowlist; negative prices rejected
- `StorefrontRenderer.maybe_add_source/2` passes sort/offset/filters through
- `hydrate_all/1` uses `Task.async_stream` (max_concurrency: 4) for parallel fetching
- Preserves component order after parallel hydration
- 9 new tests

Precommit: 414 tests, 20 pre-existing failures, 0 new