### PR TITLE
feat: layout variants — landing, sidebar, minimal (#103)

### DIFF
--- a/assets/css/storefront.css
+++ b/assets/css/storefront.css
@@ -231,6 +231,40 @@
   color: var(--sf-color-accent);
 }
 
+/* Layout variants */
+.sf-layout-landing .sf-main {
+  padding-top: 0;
+}
+
+.sf-main-with-sidebar {
+  display: flex;
+  max-width: var(--sf-max-width);
+  margin: 0 auto;
+  gap: var(--sf-space-lg);
+}
+
+.sf-sidebar {
+  flex-shrink: 0;
+  padding: var(--sf-space-md) 0;
+}
+
+.sf-sidebar-right {
+  order: 2;
+}
+
+.sf-sidebar-sticky {
+  position: sticky;
+  top: var(--sf-nav-height);
+  align-self: start;
+  max-height: calc(100vh - var(--sf-nav-height));
+  overflow-y: auto;
+}
+
+.sf-content-with-sidebar {
+  flex: 1;
+  min-width: 0;
+}
+
 .sf-nav-actions {
   display: flex;
   gap: var(--sf-space-sm);

--- a/lib/jarga_admin/storefront_renderer.ex
+++ b/lib/jarga_admin/storefront_renderer.ex
@@ -39,6 +39,29 @@ defmodule JargaAdmin.StorefrontRenderer do
 
   def render_spec(_), do: []
 
+  @valid_layouts ~w(storefront landing storefront-sidebar minimal overlay-nav)
+
+  @doc "Extract page layout from content_json, validated against allowlist."
+  def extract_layout(%{"layout" => layout}) when is_binary(layout) do
+    if layout in @valid_layouts, do: layout, else: "storefront"
+  end
+
+  def extract_layout(_), do: "storefront"
+
+  @doc "Extract sidebar config from content_json for storefront-sidebar layout."
+  def extract_sidebar(%{"sidebar" => sidebar}) when is_map(sidebar) do
+    components = render_spec(%{"components" => sidebar["components"] || []})
+
+    %{
+      position: sidebar["position"] || "left",
+      width: sidebar["width"] || "280px",
+      sticky: sidebar["sticky"] == true,
+      components: components
+    }
+  end
+
+  def extract_sidebar(_), do: nil
+
   @valid_filter_types ~w(checkbox swatch range toggle)
 
   @doc "Extract and normalize filter facets from page spec."

--- a/lib/jarga_admin_web/live/storefront_live.ex
+++ b/lib/jarga_admin_web/live/storefront_live.ex
@@ -71,6 +71,8 @@ defmodule JargaAdminWeb.StorefrontLive do
       |> assign(:filters_open, false)
       |> assign(:active_filters, %{})
       |> assign(:filter_config, [])
+      |> assign(:layout_variant, "storefront")
+      |> assign(:sidebar, nil)
       |> assign(:gallery_zoom_open, false)
       |> assign(:gallery_zoom_index, 0)
       |> assign(:gallery_zoom_images, [])
@@ -365,12 +367,13 @@ defmodule JargaAdminWeb.StorefrontLive do
         search_results={@search_results}
       />
       <StorefrontComponents.nav_bar
+        :if={@layout_variant != "landing"}
         logo={@store_name}
         links={@nav_links}
         cart_count={@cart_count}
       />
 
-      <main class="sf-main">
+      <main class={["sf-main", @layout_variant == "storefront-sidebar" && "sf-main-with-sidebar"]}>
         <%= if @error do %>
           <div class="sf-error" id="sf-error">
             <h1 class="sf-error-title">Page not found</h1>
@@ -380,13 +383,29 @@ defmodule JargaAdminWeb.StorefrontLive do
             <a href="/" class="sf-btn-primary">BACK TO HOME</a>
           </div>
         <% else %>
-          <%= for comp <- @components do %>
-            <.render_component component={comp} />
-          <% end %>
+          <aside
+            :if={@sidebar}
+            class={[
+              "sf-sidebar",
+              @sidebar.position == "right" && "sf-sidebar-right",
+              @sidebar.sticky && "sf-sidebar-sticky"
+            ]}
+            style={"width: #{@sidebar.width}"}
+          >
+            <%= for comp <- @sidebar.components do %>
+              <.render_component component={comp} />
+            <% end %>
+          </aside>
+          <div class={["sf-content", @sidebar && "sf-content-with-sidebar"]}>
+            <%= for comp <- @components do %>
+              <.render_component component={comp} />
+            <% end %>
+          </div>
         <% end %>
       </main>
 
       <StorefrontComponents.storefront_footer
+        :if={@layout_variant not in ["landing", "minimal"]}
         columns={@footer_columns}
         copyright={@footer_copyright}
       />
@@ -607,6 +626,8 @@ defmodule JargaAdminWeb.StorefrontLive do
         |> assign(:components, components)
         |> assign(:filter_config, StorefrontRenderer.extract_filters(content_json))
         |> assign(:active_filters, %{})
+        |> assign(:layout_variant, StorefrontRenderer.extract_layout(content_json))
+        |> assign(:sidebar, StorefrontRenderer.extract_sidebar(content_json))
         |> assign(:nav_links, nav_links)
         |> assign(:error, nil)
 

--- a/test/jarga_admin/storefront_renderer_test.exs
+++ b/test/jarga_admin/storefront_renderer_test.exs
@@ -501,6 +501,47 @@ defmodule JargaAdmin.StorefrontRendererTest do
       assert toggle.type == "toggle"
     end
 
+    test "extract_layout returns layout from content_json" do
+      spec = %{"layout" => "landing", "components" => []}
+      assert StorefrontRenderer.extract_layout(spec) == "landing"
+    end
+
+    test "extract_layout defaults to storefront" do
+      spec = %{"components" => []}
+      assert StorefrontRenderer.extract_layout(spec) == "storefront"
+    end
+
+    test "extract_layout rejects invalid layout" do
+      spec = %{"layout" => "evil_layout", "components" => []}
+      assert StorefrontRenderer.extract_layout(spec) == "storefront"
+    end
+
+    test "extract_sidebar returns sidebar config" do
+      spec = %{
+        "layout" => "storefront-sidebar",
+        "sidebar" => %{
+          "position" => "left",
+          "width" => "280px",
+          "sticky" => true,
+          "components" => [
+            %{"type" => "text_block", "data" => %{"heading" => "Side", "body" => "bar"}}
+          ]
+        },
+        "components" => []
+      }
+
+      sidebar = StorefrontRenderer.extract_sidebar(spec)
+      assert sidebar.position == "left"
+      assert sidebar.width == "280px"
+      assert sidebar.sticky == true
+      assert length(sidebar.components) == 1
+    end
+
+    test "extract_sidebar returns nil when no sidebar" do
+      spec = %{"components" => []}
+      assert StorefrontRenderer.extract_sidebar(spec) == nil
+    end
+
     test "extract_filters returns empty list when no filters" do
       spec = %{"components" => []}
       assert StorefrontRenderer.extract_filters(spec) == []

--- a/test/jarga_admin_web/live/storefront_live_test.exs
+++ b/test/jarga_admin_web/live/storefront_live_test.exs
@@ -873,6 +873,90 @@ defmodule JargaAdminWeb.StorefrontLiveTest do
     end
   end
 
+  describe "layout variants" do
+    test "landing layout hides nav and footer", %{conn: conn, bypass: bypass} do
+      landing_page =
+        Jason.encode!(%{
+          data: %{
+            "id" => "pg_land",
+            "slug" => "home",
+            "title" => "Landing",
+            "content_json" => %{
+              "layout" => "landing",
+              "components" => [
+                %{"type" => "text_block", "data" => %{"title" => "Hello", "content" => "World"}}
+              ]
+            }
+          }
+        })
+
+      Bypass.stub(bypass, "GET", "/v1/frontend/pages/home", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, landing_page)
+      end)
+
+      Bypass.stub(bypass, "GET", "/v1/frontend/navigation", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, navigation_spec())
+      end)
+
+      Bypass.stub(bypass, "GET", "/v1/frontend/slots/storefront_theme", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(404, Jason.encode!(%{error: "not found"}))
+      end)
+
+      {:ok, _view, html} = live(conn, "/store")
+
+      assert html =~ "Hello"
+      refute html =~ "id=\"sf-nav\""
+      refute html =~ "sf-footer"
+    end
+
+    test "minimal layout hides footer and announcement", %{conn: conn, bypass: bypass} do
+      minimal_page =
+        Jason.encode!(%{
+          data: %{
+            "id" => "pg_min",
+            "slug" => "home",
+            "title" => "Minimal",
+            "content_json" => %{
+              "layout" => "minimal",
+              "components" => [
+                %{"type" => "text_block", "data" => %{"title" => "Min", "content" => "Page"}}
+              ]
+            }
+          }
+        })
+
+      Bypass.stub(bypass, "GET", "/v1/frontend/pages/home", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, minimal_page)
+      end)
+
+      Bypass.stub(bypass, "GET", "/v1/frontend/navigation", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, navigation_spec())
+      end)
+
+      Bypass.stub(bypass, "GET", "/v1/frontend/slots/storefront_theme", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(404, Jason.encode!(%{error: "not found"}))
+      end)
+
+      {:ok, _view, html} = live(conn, "/store")
+
+      assert html =~ "Min"
+      assert html =~ "id=\"sf-nav\""
+      refute html =~ "sf-footer"
+    end
+  end
+
   describe "per-component styling" do
     test "renders component with inline style from page spec", %{conn: conn, bypass: bypass} do
       styled_spec =


### PR DESCRIPTION
Closes #103

## Changes
- `extract_layout/1` + `extract_sidebar/1` in StorefrontRenderer
- 5 layout variants: storefront, landing, storefront-sidebar, minimal, overlay-nav
- Landing: no nav/footer — pure component page
- Minimal: nav + content, no footer/announcement
- Sidebar: two-column with sticky aside + position control
- 7 new tests

Precommit: 421/20