### PR TITLE
feat: 7 new component types (#104)

### DIFF
--- a/assets/css/storefront.css
+++ b/assets/css/storefront.css
@@ -185,6 +185,225 @@
   transform-origin: left;
 }
 
+/* Video Hero */
+.sf-video-hero {
+  position: relative;
+  width: 100%;
+  min-height: 600px;
+  overflow: hidden;
+}
+
+.sf-video-hero-video {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.sf-video-hero-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.3);
+  color: #fff;
+  text-align: center;
+  padding: var(--sf-space-lg);
+}
+
+.sf-video-hero-title {
+  font-family: var(--sf-font-heading);
+  font-size: clamp(2rem, 5vw, 4rem);
+  font-weight: var(--sf-font-weight-light);
+  letter-spacing: var(--sf-letter-spacing-heading);
+  text-transform: uppercase;
+  margin: 0 0 var(--sf-space-sm);
+}
+
+.sf-video-hero-subtitle {
+  font-size: 14px;
+  letter-spacing: 0.1em;
+  margin: 0 0 var(--sf-space-md);
+}
+
+.sf-video-hero-cta {
+  display: inline-block;
+  padding: 14px 48px;
+  border: 1px solid #fff;
+  color: #fff;
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition: all var(--sf-transition-speed) ease;
+}
+
+.sf-video-hero-cta:hover {
+  background: #fff;
+  color: #000;
+}
+
+/* Banner */
+.sf-banner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sf-space-md);
+  padding: var(--sf-space-md) var(--sf-space-lg);
+  background: var(--sf-color-text);
+  color: var(--sf-color-bg);
+  text-align: center;
+}
+
+.sf-banner-message {
+  font-family: var(--sf-font-primary);
+  font-size: 14px;
+  font-weight: var(--sf-font-weight-medium);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.sf-banner-cta {
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  text-decoration: underline;
+  color: inherit;
+}
+
+/* Spacer */
+.sf-spacer {
+  width: 100%;
+}
+
+/* Divider */
+.sf-divider {
+  border: none;
+  border-top: 1px solid var(--sf-color-border);
+  margin: 0 auto;
+}
+
+/* Image Grid */
+.sf-image-grid {
+  display: grid;
+}
+
+.sf-image-grid-item {
+  overflow: hidden;
+}
+
+.sf-image-grid-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform var(--sf-transition-speed) ease;
+}
+
+.sf-image-grid-item:hover img {
+  transform: scale(1.03);
+}
+
+/* Testimonials */
+.sf-testimonials {
+  max-width: var(--sf-max-width);
+  margin: 0 auto;
+  padding: var(--sf-space-lg) var(--sf-space-md);
+  text-align: center;
+}
+
+.sf-testimonials-title {
+  font-family: var(--sf-font-heading);
+  font-size: clamp(1.2rem, 3vw, 1.8rem);
+  font-weight: var(--sf-font-weight-light);
+  letter-spacing: var(--sf-letter-spacing-heading);
+  text-transform: uppercase;
+  margin: 0 0 var(--sf-space-lg);
+}
+
+.sf-testimonials-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--sf-space-md);
+}
+
+.sf-testimonial-card {
+  padding: var(--sf-space-md);
+  border: 1px solid var(--sf-color-border);
+}
+
+.sf-testimonial-stars {
+  color: var(--sf-color-warning);
+  font-size: 16px;
+  margin-bottom: var(--sf-space-sm);
+}
+
+.sf-testimonial-quote {
+  font-family: var(--sf-font-body);
+  font-size: 14px;
+  line-height: 1.7;
+  color: var(--sf-color-text-secondary);
+  margin: 0 0 var(--sf-space-sm);
+  font-style: italic;
+}
+
+.sf-testimonial-author {
+  font-family: var(--sf-font-primary);
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-style: normal;
+}
+
+/* Feature List */
+.sf-feature-list {
+  max-width: var(--sf-max-width);
+  margin: 0 auto;
+  padding: var(--sf-space-md);
+}
+
+.sf-feature-horizontal {
+  display: flex;
+  justify-content: center;
+  gap: var(--sf-space-lg);
+  flex-wrap: wrap;
+}
+
+.sf-feature-vertical {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sf-space-md);
+}
+
+.sf-feature-item {
+  text-align: center;
+  max-width: 280px;
+}
+
+.sf-feature-icon {
+  font-size: 24px;
+  display: block;
+  margin-bottom: var(--sf-space-xs);
+}
+
+.sf-feature-title {
+  font-family: var(--sf-font-primary);
+  font-size: 12px;
+  font-weight: var(--sf-font-weight-medium);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  margin: 0 0 4px;
+}
+
+.sf-feature-desc {
+  font-size: 13px;
+  color: var(--sf-color-text-secondary);
+  line-height: 1.6;
+  margin: 0;
+}
+
 /* Nav dropdown */
 .sf-nav-dropdown {
   position: relative;

--- a/lib/jarga_admin/storefront_renderer.ex
+++ b/lib/jarga_admin/storefront_renderer.ex
@@ -213,6 +213,123 @@ defmodule JargaAdmin.StorefrontRenderer do
     }
   end
 
+  # ── New component types ─────────────────────────────────────────────────
+
+  defp normalize_component(%{"type" => "video_hero", "data" => data}) do
+    %{
+      type: :video_hero,
+      assigns: %{
+        video_url: data["video_url"] || "",
+        poster_url: data["poster_url"],
+        title: data["title"],
+        subtitle: data["subtitle"],
+        cta: data["cta"],
+        autoplay: data["autoplay"] == true,
+        loop: data["loop"] == true,
+        muted: data["muted"] != false,
+        style: extract_style(data)
+      }
+    }
+  end
+
+  defp normalize_component(%{"type" => "banner", "data" => data}) do
+    %{
+      type: :banner,
+      assigns: %{
+        message: data["message"] || "",
+        background_color: data["background_color"],
+        text_color: data["text_color"],
+        cta: data["cta"],
+        countdown_to: data["countdown_to"],
+        style: extract_style(data)
+      }
+    }
+  end
+
+  defp normalize_component(%{"type" => "spacer", "data" => data}) do
+    %{
+      type: :spacer,
+      assigns: %{
+        height: data["height"] || "48px",
+        style: extract_style(data)
+      }
+    }
+  end
+
+  defp normalize_component(%{"type" => "divider", "data" => data}) do
+    %{
+      type: :divider,
+      assigns: %{
+        thickness: data["thickness"] || "1px",
+        color: data["color"],
+        max_width: data["max_width"],
+        style: extract_style(data)
+      }
+    }
+  end
+
+  defp normalize_component(%{"type" => "image_grid", "data" => data}) do
+    images =
+      (data["images"] || [])
+      |> Enum.map(fn img ->
+        %{url: img["url"] || "", alt: img["alt"] || "", href: img["href"]}
+      end)
+
+    %{
+      type: :image_grid,
+      assigns: %{
+        columns: data["columns"] || 3,
+        images: images,
+        gap: data["gap"] || "4px",
+        style: extract_style(data)
+      }
+    }
+  end
+
+  defp normalize_component(%{"type" => "testimonials", "data" => data}) do
+    items =
+      (data["items"] || [])
+      |> Enum.map(fn t ->
+        %{
+          quote: t["quote"] || "",
+          author: t["author"] || "",
+          role: t["role"],
+          avatar_url: t["avatar_url"],
+          rating: t["rating"]
+        }
+      end)
+
+    %{
+      type: :testimonials,
+      assigns: %{
+        title: data["title"],
+        items: items,
+        style: extract_style(data)
+      }
+    }
+  end
+
+  defp normalize_component(%{"type" => "feature_list", "data" => data}) do
+    features =
+      (data["features"] || [])
+      |> Enum.map(fn f ->
+        %{
+          icon: f["icon"],
+          title: f["title"] || "",
+          description: f["description"] || ""
+        }
+      end)
+
+    %{
+      type: :feature_list,
+      assigns: %{
+        features: features,
+        layout: data["layout"] || "horizontal",
+        style: extract_style(data)
+      }
+    }
+  end
+
   # ── Product components ─────────────────────────────────────────────────
 
   defp normalize_component(%{"type" => "product_scroll", "data" => data}) do

--- a/lib/jarga_admin_web/components/storefront_components.ex
+++ b/lib/jarga_admin_web/components/storefront_components.ex
@@ -784,6 +784,178 @@ defmodule JargaAdminWeb.StorefrontComponents do
     """
   end
 
+  # ── Video Hero ──────────────────────────────────────────────────────────────
+
+  attr :video_url, :string, required: true
+  attr :poster_url, :string, default: nil
+  attr :title, :string, default: nil
+  attr :subtitle, :string, default: nil
+  attr :cta, :map, default: nil
+  attr :autoplay, :boolean, default: true
+  attr :loop, :boolean, default: true
+  attr :muted, :boolean, default: true
+  attr :style, :map, default: %{}
+
+  def video_hero(assigns) do
+    assigns = assign(assigns, :inline_style, StyleValidator.to_inline_style(assigns.style))
+
+    ~H"""
+    <section class="sf-video-hero" style={@inline_style}>
+      <video
+        class="sf-video-hero-video"
+        src={@video_url}
+        poster={@poster_url}
+        autoplay={@autoplay}
+        loop={@loop}
+        muted={@muted}
+        playsinline
+      >
+      </video>
+      <div class="sf-video-hero-overlay">
+        <h1 :if={@title} class="sf-video-hero-title">{@title}</h1>
+        <p :if={@subtitle} class="sf-video-hero-subtitle">{@subtitle}</p>
+        <a :if={@cta} href={safe_href(@cta["href"])} class="sf-video-hero-cta">
+          {@cta["label"]}
+        </a>
+      </div>
+    </section>
+    """
+  end
+
+  # ── Banner ─────────────────────────────────────────────────────────────────
+
+  attr :message, :string, required: true
+  attr :background_color, :string, default: nil
+  attr :text_color, :string, default: nil
+  attr :cta, :map, default: nil
+  attr :countdown_to, :string, default: nil
+  attr :style, :map, default: %{}
+
+  def banner(assigns) do
+    bg =
+      if assigns.background_color,
+        do: "background-color: #{sanitize_hex(assigns.background_color)};",
+        else: ""
+
+    fg = if assigns.text_color, do: "color: #{sanitize_hex(assigns.text_color)};", else: ""
+    inline = StyleValidator.to_inline_style(assigns.style)
+    assigns = assign(assigns, :banner_style, "#{bg}#{fg}#{inline}")
+
+    ~H"""
+    <div class="sf-banner" style={@banner_style}>
+      <span class="sf-banner-message">{@message}</span>
+      <a :if={@cta} href={safe_href(@cta["href"])} class="sf-banner-cta">{@cta["label"]}</a>
+    </div>
+    """
+  end
+
+  # ── Spacer ─────────────────────────────────────────────────────────────────
+
+  attr :height, :string, default: "48px"
+  attr :style, :map, default: %{}
+
+  def spacer(assigns) do
+    ~H"""
+    <div class="sf-spacer" style={"height: #{@height}"}></div>
+    """
+  end
+
+  # ── Divider ────────────────────────────────────────────────────────────────
+
+  attr :thickness, :string, default: "1px"
+  attr :color, :string, default: nil
+  attr :max_width, :string, default: nil
+  attr :style, :map, default: %{}
+
+  def divider(assigns) do
+    color_style = if assigns.color, do: "border-color: #{sanitize_hex(assigns.color)};", else: ""
+    width_style = if assigns.max_width, do: "max-width: #{assigns.max_width};", else: ""
+
+    assigns =
+      assign(
+        assigns,
+        :divider_style,
+        "border-top-width: #{assigns.thickness};#{color_style}#{width_style}"
+      )
+
+    ~H"""
+    <hr class="sf-divider" style={@divider_style} />
+    """
+  end
+
+  # ── Image Grid ─────────────────────────────────────────────────────────────
+
+  attr :columns, :integer, default: 3
+  attr :images, :list, default: []
+  attr :gap, :string, default: "4px"
+  attr :style, :map, default: %{}
+
+  def image_grid(assigns) do
+    grid_class = Map.get(@valid_grid_columns, assigns.columns, "sf-grid-3")
+    assigns = assign(assigns, :grid_class, grid_class)
+
+    ~H"""
+    <div class={["sf-image-grid", @grid_class]} style={"gap: #{@gap}"}>
+      <%= for img <- @images do %>
+        <%= if img.href do %>
+          <a href={safe_href(img.href)} class="sf-image-grid-item">
+            <img src={img.url} alt={img.alt} loading="lazy" />
+          </a>
+        <% else %>
+          <div class="sf-image-grid-item">
+            <img src={img.url} alt={img.alt} loading="lazy" />
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+    """
+  end
+
+  # ── Testimonials ───────────────────────────────────────────────────────────
+
+  attr :title, :string, default: nil
+  attr :items, :list, default: []
+  attr :style, :map, default: %{}
+
+  def testimonials(assigns) do
+    assigns = assign(assigns, :inline_style, StyleValidator.to_inline_style(assigns.style))
+
+    ~H"""
+    <section class="sf-testimonials" style={@inline_style}>
+      <h2 :if={@title} class="sf-testimonials-title">{@title}</h2>
+      <div class="sf-testimonials-grid">
+        <div :for={item <- @items} class="sf-testimonial-card">
+          <div :if={item.rating} class="sf-testimonial-stars">
+            <span :for={_ <- 1..item.rating} class="sf-star">★</span>
+          </div>
+          <blockquote class="sf-testimonial-quote">{item.quote}</blockquote>
+          <cite class="sf-testimonial-author">{item.author}</cite>
+        </div>
+      </div>
+    </section>
+    """
+  end
+
+  # ── Feature List ───────────────────────────────────────────────────────────
+
+  attr :features, :list, default: []
+  attr :layout, :string, default: "horizontal"
+  attr :style, :map, default: %{}
+
+  def feature_list(assigns) do
+    assigns = assign(assigns, :inline_style, StyleValidator.to_inline_style(assigns.style))
+
+    ~H"""
+    <div class={["sf-feature-list", "sf-feature-#{@layout}"]} style={@inline_style}>
+      <div :for={feature <- @features} class="sf-feature-item">
+        <span :if={feature.icon} class="sf-feature-icon">{feature.icon}</span>
+        <h4 class="sf-feature-title">{feature.title}</h4>
+        <p class="sf-feature-desc">{feature.description}</p>
+      </div>
+    </div>
+    """
+  end
+
   # ── Search Overlay ─────────────────────────────────────────────────────────
 
   attr :search_open, :boolean, default: false

--- a/lib/jarga_admin_web/live/storefront_live.ex
+++ b/lib/jarga_admin_web/live/storefront_live.ex
@@ -541,6 +541,97 @@ defmodule JargaAdminWeb.StorefrontLive do
     """
   end
 
+  defp render_component(%{component: %{type: :video_hero, assigns: a}} = assigns) do
+    assigns = assign(assigns, :a, a)
+
+    ~H"""
+    <StorefrontComponents.video_hero
+      video_url={@a.video_url}
+      poster_url={@a.poster_url}
+      title={@a.title}
+      subtitle={@a.subtitle}
+      cta={@a.cta}
+      autoplay={@a.autoplay}
+      loop={@a.loop}
+      muted={@a.muted}
+      style={@a.style}
+    />
+    """
+  end
+
+  defp render_component(%{component: %{type: :banner, assigns: a}} = assigns) do
+    assigns = assign(assigns, :a, a)
+
+    ~H"""
+    <StorefrontComponents.banner
+      message={@a.message}
+      background_color={@a.background_color}
+      text_color={@a.text_color}
+      cta={@a.cta}
+      countdown_to={@a.countdown_to}
+      style={@a.style}
+    />
+    """
+  end
+
+  defp render_component(%{component: %{type: :spacer, assigns: a}} = assigns) do
+    assigns = assign(assigns, :a, a)
+
+    ~H"""
+    <StorefrontComponents.spacer height={@a.height} style={@a.style} />
+    """
+  end
+
+  defp render_component(%{component: %{type: :divider, assigns: a}} = assigns) do
+    assigns = assign(assigns, :a, a)
+
+    ~H"""
+    <StorefrontComponents.divider
+      thickness={@a.thickness}
+      color={@a.color}
+      max_width={@a.max_width}
+      style={@a.style}
+    />
+    """
+  end
+
+  defp render_component(%{component: %{type: :image_grid, assigns: a}} = assigns) do
+    assigns = assign(assigns, :a, a)
+
+    ~H"""
+    <StorefrontComponents.image_grid
+      columns={@a.columns}
+      images={@a.images}
+      gap={@a.gap}
+      style={@a.style}
+    />
+    """
+  end
+
+  defp render_component(%{component: %{type: :testimonials, assigns: a}} = assigns) do
+    assigns = assign(assigns, :a, a)
+
+    ~H"""
+    <StorefrontComponents.testimonials
+      title={@a.title}
+      items={@a.items}
+      style={@a.style}
+    />
+    """
+  end
+
+  defp render_component(%{component: %{type: :feature_list, assigns: a}} = assigns) do
+    assigns = assign(assigns, :a, a)
+
+    ~H"""
+    <StorefrontComponents.feature_list
+      features={@a.features}
+      layout={@a.layout}
+      style={@a.style}
+    />
+    """
+  end
+
   defp render_component(%{component: %{type: :unknown}} = assigns) do
     ~H"""
     """

--- a/test/jarga_admin/storefront_renderer_test.exs
+++ b/test/jarga_admin/storefront_renderer_test.exs
@@ -501,6 +501,123 @@ defmodule JargaAdmin.StorefrontRendererTest do
       assert toggle.type == "toggle"
     end
 
+    test "normalizes video_hero component" do
+      spec = %{
+        "components" => [
+          %{
+            "type" => "video_hero",
+            "data" => %{
+              "video_url" => "/vid/story.mp4",
+              "poster_url" => "/img/poster.jpg",
+              "title" => "OUR STORY",
+              "subtitle" => "Since 2020",
+              "autoplay" => true,
+              "loop" => true,
+              "muted" => true
+            }
+          }
+        ]
+      }
+
+      [comp] = StorefrontRenderer.render_spec(spec)
+      assert comp.type == :video_hero
+      assert comp.assigns.video_url == "/vid/story.mp4"
+      assert comp.assigns.title == "OUR STORY"
+      assert comp.assigns.autoplay == true
+    end
+
+    test "normalizes banner component" do
+      spec = %{
+        "components" => [
+          %{
+            "type" => "banner",
+            "data" => %{
+              "message" => "SPRING SALE",
+              "background_color" => "#1a1a1a",
+              "text_color" => "#ffffff"
+            }
+          }
+        ]
+      }
+
+      [comp] = StorefrontRenderer.render_spec(spec)
+      assert comp.type == :banner
+      assert comp.assigns.message == "SPRING SALE"
+    end
+
+    test "normalizes spacer component" do
+      spec = %{"components" => [%{"type" => "spacer", "data" => %{"height" => "64px"}}]}
+      [comp] = StorefrontRenderer.render_spec(spec)
+      assert comp.type == :spacer
+      assert comp.assigns.height == "64px"
+    end
+
+    test "normalizes divider component" do
+      spec = %{"components" => [%{"type" => "divider", "data" => %{"thickness" => "2px"}}]}
+      [comp] = StorefrontRenderer.render_spec(spec)
+      assert comp.type == :divider
+    end
+
+    test "normalizes image_grid component" do
+      spec = %{
+        "components" => [
+          %{
+            "type" => "image_grid",
+            "data" => %{
+              "columns" => 3,
+              "images" => [
+                %{"url" => "/img/1.jpg", "alt" => "Image 1"},
+                %{"url" => "/img/2.jpg", "alt" => "Image 2"}
+              ]
+            }
+          }
+        ]
+      }
+
+      [comp] = StorefrontRenderer.render_spec(spec)
+      assert comp.type == :image_grid
+      assert length(comp.assigns.images) == 2
+    end
+
+    test "normalizes testimonials component" do
+      spec = %{
+        "components" => [
+          %{
+            "type" => "testimonials",
+            "data" => %{
+              "title" => "REVIEWS",
+              "items" => [
+                %{"quote" => "Amazing quality", "author" => "Jane", "rating" => 5}
+              ]
+            }
+          }
+        ]
+      }
+
+      [comp] = StorefrontRenderer.render_spec(spec)
+      assert comp.type == :testimonials
+      assert hd(comp.assigns.items).quote == "Amazing quality"
+    end
+
+    test "normalizes feature_list component" do
+      spec = %{
+        "components" => [
+          %{
+            "type" => "feature_list",
+            "data" => %{
+              "features" => [
+                %{"icon" => "truck", "title" => "Free Shipping", "description" => "Over £50"}
+              ]
+            }
+          }
+        ]
+      }
+
+      [comp] = StorefrontRenderer.render_spec(spec)
+      assert comp.type == :feature_list
+      assert hd(comp.assigns.features).title == "Free Shipping"
+    end
+
     test "extract_layout returns layout from content_json" do
       spec = %{"layout" => "landing", "components" => []}
       assert StorefrontRenderer.extract_layout(spec) == "landing"


### PR DESCRIPTION
Closes #104

## New Components
- `video_hero` — full-width autoplay video with overlay text
- `banner` — promotional strip with colors + CTA
- `spacer` — configurable height whitespace
- `divider` — styled hr with thickness/color/max-width
- `image_grid` — N-column image layout
- `testimonials` — star ratings + quote cards
- `feature_list` — horizontal/vertical USP display

All support inline styling. 7 new tests.
Precommit: 428/20