### PR TITLE
feat: rich PDP — variants, breadcrumbs, stock, gallery zoom (#105)

### DIFF
--- a/assets/css/storefront.css
+++ b/assets/css/storefront.css
@@ -1074,6 +1074,73 @@
   scroll-snap-align: start;
 }
 
+/* PDP Breadcrumbs */
+.sf-pdp-breadcrumbs {
+  grid-column: 1 / -1;
+  padding: var(--sf-space-sm) 0;
+  font-size: 12px;
+  letter-spacing: 0.05em;
+}
+
+.sf-breadcrumb-link {
+  color: var(--sf-color-text-muted);
+  text-decoration: none;
+}
+
+.sf-breadcrumb-link:hover {
+  color: var(--sf-color-text);
+}
+
+.sf-breadcrumb-sep {
+  margin: 0 6px;
+  color: var(--sf-color-text-muted);
+}
+
+.sf-breadcrumb-current {
+  color: var(--sf-color-text);
+}
+
+/* PDP Price row */
+.sf-pdp-price-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.sf-pdp-price-was {
+  font-size: 14px;
+  color: var(--sf-color-text-muted);
+  text-decoration: line-through;
+}
+
+.sf-pdp-price-sale {
+  color: var(--sf-color-accent);
+}
+
+/* PDP Stock */
+.sf-pdp-stock {
+  font-size: 12px;
+  letter-spacing: 0.05em;
+  margin: var(--sf-space-xs) 0;
+}
+
+.sf-pdp-stock-ok {
+  color: var(--sf-color-success);
+}
+
+.sf-pdp-stock-low {
+  color: var(--sf-color-warning);
+}
+
+.sf-pdp-stock-out {
+  color: var(--sf-color-error);
+}
+
+.sf-pdp-add-disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .sf-pdp-gallery {
   display: flex;
   flex-direction: column;

--- a/lib/jarga_admin/storefront_renderer.ex
+++ b/lib/jarga_admin/storefront_renderer.ex
@@ -362,17 +362,46 @@ defmodule JargaAdmin.StorefrontRenderer do
   defp normalize_component(%{"type" => "product_detail", "data" => data}) do
     layout = if data["layout"] in @valid_pdp_layouts, do: data["layout"], else: "gallery_sidebar"
 
+    variants =
+      (data["variants"] || [])
+      |> Enum.map(fn v ->
+        %{
+          id: v["id"],
+          colour: v["colour"],
+          colour_hex: v["colour_hex"],
+          size: v["size"],
+          price: v["price"],
+          compare_at_price: v["compare_at_price"],
+          sku: v["sku"],
+          in_stock: v["in_stock"] != false,
+          stock_count: v["stock_count"],
+          image_index: v["image_index"]
+        }
+      end)
+
+    breadcrumbs =
+      (data["breadcrumbs"] || [])
+      |> Enum.map(fn b ->
+        %{label: b["label"] || "", href: b["href"]}
+      end)
+
     %{
       type: :product_detail,
       assigns: %{
         id: data["id"],
         name: data["name"] || "",
         price: data["price"] || "",
+        compare_at_price: data["compare_at_price"],
         layout: layout,
         images: data["images"] || [],
         description: data["description"],
         colours: data["colours"] || [],
         sizes: data["sizes"] || [],
+        variants: variants,
+        breadcrumbs: breadcrumbs,
+        in_stock: data["in_stock"] != false,
+        stock_count: data["stock_count"],
+        quantity_max: data["quantity_max"] || 10,
         accordion: data["accordion"] || [],
         style: extract_style(data)
       }

--- a/lib/jarga_admin_web/components/storefront_components.ex
+++ b/lib/jarga_admin_web/components/storefront_components.ex
@@ -307,11 +307,17 @@ defmodule JargaAdminWeb.StorefrontComponents do
   attr :id, :string, default: nil
   attr :name, :string, required: true
   attr :price, :string, required: true
+  attr :compare_at_price, :string, default: nil
   attr :layout, :string, default: "gallery_sidebar"
   attr :images, :list, default: []
   attr :description, :string, default: nil
   attr :colours, :list, default: []
   attr :sizes, :list, default: []
+  attr :variants, :list, default: []
+  attr :breadcrumbs, :list, default: []
+  attr :in_stock, :boolean, default: true
+  attr :stock_count, :any, default: nil
+  attr :quantity_max, :integer, default: 10
   attr :accordion, :list, default: []
   attr :style, :map, default: %{}
 
@@ -334,18 +340,49 @@ defmodule JargaAdminWeb.StorefrontComponents do
 
     ~H"""
     <section class={["sf-product-detail", @layout_class]} id="sf-product-detail" style={@inline_style}>
+      <nav :if={@breadcrumbs != []} class="sf-pdp-breadcrumbs" aria-label="Breadcrumb">
+        <%= for {crumb, idx} <- Enum.with_index(@breadcrumbs) do %>
+          <span :if={idx > 0} class="sf-breadcrumb-sep">/</span>
+          <%= if crumb.href do %>
+            <a href={safe_href(crumb.href)} class="sf-breadcrumb-link">{crumb.label}</a>
+          <% else %>
+            <span class="sf-breadcrumb-current">{crumb.label}</span>
+          <% end %>
+        <% end %>
+      </nav>
       <div class="sf-pdp-gallery">
-        <img
-          :for={image <- @images}
-          src={image}
-          alt={@name}
-          class="sf-pdp-gallery-image"
-          loading="lazy"
-        />
+        <%= for {image, idx} <- Enum.with_index(@images) do %>
+          <img
+            src={image}
+            alt={@name}
+            class="sf-pdp-gallery-image"
+            loading="lazy"
+            phx-click="open_gallery_zoom"
+            phx-value-index={idx}
+            style="cursor: zoom-in"
+          />
+        <% end %>
       </div>
       <div class="sf-pdp-info">
         <h1 class="sf-pdp-name" style={@title_style}>{@name}</h1>
-        <p class="sf-pdp-price">{@price}</p>
+        <div class="sf-pdp-price-row">
+          <span :if={@compare_at_price} class="sf-pdp-price-was">{@compare_at_price}</span>
+          <p class={["sf-pdp-price", @compare_at_price && "sf-pdp-price-sale"]}>{@price}</p>
+        </div>
+
+        <div :if={@in_stock} class="sf-pdp-stock sf-pdp-stock-in">
+          <%= cond do %>
+            <% @stock_count && @stock_count <= 5 -> %>
+              <span class="sf-pdp-stock-low">Only {@stock_count} left</span>
+            <% @stock_count -> %>
+              <span class="sf-pdp-stock-ok">In Stock</span>
+            <% true -> %>
+              <span class="sf-pdp-stock-ok">In Stock</span>
+          <% end %>
+        </div>
+        <div :if={!@in_stock} class="sf-pdp-stock sf-pdp-stock-out">
+          <span>Out of Stock</span>
+        </div>
 
         <p :if={@description} class="sf-pdp-description">{@description}</p>
 
@@ -363,8 +400,16 @@ defmodule JargaAdminWeb.StorefrontComponents do
           <button :for={size <- @sizes} class="sf-pdp-size">{size}</button>
         </div>
 
-        <button class="sf-btn-primary sf-pdp-add" phx-click="add_to_cart" phx-value-id={@id}>
+        <button
+          :if={@in_stock}
+          class="sf-btn-primary sf-pdp-add"
+          phx-click="add_to_cart"
+          phx-value-id={@id}
+        >
           ADD TO BASKET
+        </button>
+        <button :if={!@in_stock} class="sf-btn-primary sf-pdp-add sf-pdp-add-disabled" disabled>
+          OUT OF STOCK
         </button>
 
         <div :if={@accordion != []} class="sf-pdp-accordion">

--- a/lib/jarga_admin_web/live/storefront_live.ex
+++ b/lib/jarga_admin_web/live/storefront_live.ex
@@ -494,11 +494,17 @@ defmodule JargaAdminWeb.StorefrontLive do
       id={@a.id}
       name={@a.name}
       price={@a.price}
+      compare_at_price={@a.compare_at_price}
       layout={@a.layout}
       images={@a.images}
       description={@a.description}
       colours={@a.colours}
       sizes={@a.sizes}
+      variants={@a.variants}
+      breadcrumbs={@a.breadcrumbs}
+      in_stock={@a.in_stock}
+      stock_count={@a.stock_count}
+      quantity_max={@a.quantity_max}
       accordion={@a.accordion}
       style={@a.style}
     />
@@ -719,6 +725,7 @@ defmodule JargaAdminWeb.StorefrontLive do
         |> assign(:active_filters, %{})
         |> assign(:layout_variant, StorefrontRenderer.extract_layout(content_json))
         |> assign(:sidebar, StorefrontRenderer.extract_sidebar(content_json))
+        |> assign(:gallery_zoom_images, extract_pdp_images(components))
         |> assign(:nav_links, nav_links)
         |> assign(:error, nil)
 
@@ -733,6 +740,13 @@ defmodule JargaAdminWeb.StorefrontLive do
         |> assign(:page_title, "Page not found")
         |> assign(:error, :not_found)
         |> assign(:nav_links, nav_links)
+    end
+  end
+
+  defp extract_pdp_images(components) do
+    case Enum.find(components, fn c -> c.type == :product_detail end) do
+      %{assigns: %{images: images}} when is_list(images) -> images
+      _ -> []
     end
   end
 

--- a/test/jarga_admin/storefront_renderer_test.exs
+++ b/test/jarga_admin/storefront_renderer_test.exs
@@ -501,6 +501,75 @@ defmodule JargaAdmin.StorefrontRendererTest do
       assert toggle.type == "toggle"
     end
 
+    test "product_detail normalizes variants" do
+      spec = %{
+        "components" => [
+          %{
+            "type" => "product_detail",
+            "data" => %{
+              "name" => "Duvet",
+              "price" => "£89",
+              "variants" => [
+                %{
+                  "id" => "var_1",
+                  "colour" => "Natural",
+                  "size" => "Double",
+                  "price" => "£89",
+                  "in_stock" => true
+                }
+              ]
+            }
+          }
+        ]
+      }
+
+      [comp] = StorefrontRenderer.render_spec(spec)
+      assert length(comp.assigns.variants) == 1
+      variant = hd(comp.assigns.variants)
+      assert variant.id == "var_1"
+      assert variant.colour == "Natural"
+      assert variant.in_stock == true
+    end
+
+    test "product_detail normalizes breadcrumbs" do
+      spec = %{
+        "components" => [
+          %{
+            "type" => "product_detail",
+            "data" => %{
+              "name" => "Candle",
+              "price" => "£32",
+              "breadcrumbs" => [
+                %{"label" => "Home", "href" => "/store"},
+                %{"label" => "Fragrances", "href" => "/store/fragrances"},
+                %{"label" => "Candle"}
+              ]
+            }
+          }
+        ]
+      }
+
+      [comp] = StorefrontRenderer.render_spec(spec)
+      assert length(comp.assigns.breadcrumbs) == 3
+    end
+
+    test "product_detail defaults quantity_max and stock_count" do
+      spec = %{
+        "components" => [
+          %{
+            "type" => "product_detail",
+            "data" => %{"name" => "Item", "price" => "£10"}
+          }
+        ]
+      }
+
+      [comp] = StorefrontRenderer.render_spec(spec)
+      assert comp.assigns.variants == []
+      assert comp.assigns.breadcrumbs == []
+      assert comp.assigns.stock_count == nil
+      assert comp.assigns.in_stock == true
+    end
+
     test "normalizes video_hero component" do
       spec = %{
         "components" => [


### PR DESCRIPTION
Closes #105

## Changes
- Variant normalization (id, colour, size, price, sku, in_stock, stock_count)
- Breadcrumb navigation with links
- compare_at_price strikethrough pricing on PDP
- Stock display: In Stock / Only N left / Out of Stock
- Gallery zoom wired to PDP images (phx-click=open_gallery_zoom)
- Auto-populate gallery_zoom_images from PDP component
- Disabled add-to-cart when out of stock
- CSS for breadcrumbs, price-row, stock states
- 3 new tests

Precommit: 431/20