### PR TITLE
feat: basket quantity controls, subtotal, remove (#108)

### DIFF
--- a/assets/css/storefront.css
+++ b/assets/css/storefront.css
@@ -1545,6 +1545,52 @@
   color: var(--sf-color-text-secondary);
 }
 
+.sf-cart-item-qty-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.sf-cart-qty-btn {
+  width: 24px;
+  height: 24px;
+  border: 1px solid var(--sf-color-border);
+  background: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  color: var(--sf-color-text);
+  transition: background var(--sf-transition-speed) ease;
+}
+
+.sf-cart-qty-btn:hover {
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.sf-cart-item-qty {
+  font-size: 13px;
+  min-width: 20px;
+  text-align: center;
+}
+
+.sf-cart-item-remove {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--sf-color-text-muted);
+  font-size: 18px;
+  padding: 4px;
+  align-self: start;
+  transition: color var(--sf-transition-speed) ease;
+}
+
+.sf-cart-item-remove:hover {
+  color: var(--sf-color-text);
+}
+
 .sf-cart-drawer-footer {
   padding: var(--sf-space-md);
   border-top: 1px solid var(--sf-color-border);

--- a/lib/jarga_admin_web/components/storefront_components.ex
+++ b/lib/jarga_admin_web/components/storefront_components.ex
@@ -527,7 +527,34 @@ defmodule JargaAdminWeb.StorefrontComponents do
             <div class="sf-cart-item-info">
               <span class="sf-cart-item-name">{item["name"]}</span>
               <span class="sf-cart-item-price">{item["price"]}</span>
+              <div class="sf-cart-item-qty-row">
+                <button
+                  class="sf-cart-qty-btn"
+                  phx-click="update_cart_quantity"
+                  phx-value-id={item["id"]}
+                  phx-value-delta="-1"
+                >
+                  −
+                </button>
+                <span class="sf-cart-item-qty">{item["quantity"] || 1}</span>
+                <button
+                  class="sf-cart-qty-btn"
+                  phx-click="update_cart_quantity"
+                  phx-value-id={item["id"]}
+                  phx-value-delta="1"
+                >
+                  +
+                </button>
+              </div>
             </div>
+            <button
+              class="sf-cart-item-remove"
+              phx-click="remove_from_cart"
+              phx-value-id={item["id"]}
+              aria-label="Remove"
+            >
+              ×
+            </button>
           </div>
         </div>
         <div :if={@items != []} class="sf-cart-drawer-footer">

--- a/lib/jarga_admin_web/live/storefront_live.ex
+++ b/lib/jarga_admin_web/live/storefront_live.ex
@@ -63,6 +63,7 @@ defmodule JargaAdminWeb.StorefrontLive do
       |> assign(:cart_open, false)
       |> assign(:cart_items, [])
       |> assign(:cart_count, 0)
+      |> assign(:cart_subtotal, "£0.00")
       |> assign(:mobile_menu_open, false)
       |> assign(:search_open, false)
       |> assign(:search_query, "")
@@ -292,10 +293,70 @@ defmodule JargaAdminWeb.StorefrontLive do
     {:noreply, update_cart(socket, updated)}
   end
 
+  @impl true
+  def handle_event("update_cart_quantity", %{"id" => id, "delta" => delta}, socket) do
+    delta_int =
+      case Integer.parse(to_string(delta)) do
+        {n, _} -> n
+        _ -> 0
+      end
+
+    updated =
+      socket.assigns.cart_items
+      |> Enum.map(fn item ->
+        if item["id"] == id do
+          new_qty = max(1, (item["quantity"] || 1) + delta_int)
+          Map.put(item, "quantity", new_qty)
+        else
+          item
+        end
+      end)
+
+    {:noreply, update_cart(socket, updated)}
+  end
+
   defp update_cart(socket, items) do
+    total_qty = Enum.reduce(items, 0, fn item, acc -> acc + (item["quantity"] || 1) end)
+    subtotal = compute_subtotal(items)
+
     socket
     |> assign(:cart_items, items)
-    |> assign(:cart_count, length(items))
+    |> assign(:cart_count, total_qty)
+    |> assign(:cart_subtotal, subtotal)
+  end
+
+  defp compute_subtotal(items) do
+    total =
+      Enum.reduce(items, 0.0, fn item, acc ->
+        price_str = item["price"] || "0"
+        qty = item["quantity"] || 1
+        # Parse price like "£89.00" or "$10.50"
+        case Regex.run(~r/[\d.]+/, price_str) do
+          [num] ->
+            case Float.parse(num) do
+              {val, _} -> acc + val * qty
+              _ -> acc
+            end
+
+          _ ->
+            acc
+        end
+      end)
+
+    # Determine currency symbol from first item
+    symbol =
+      case items do
+        [first | _] ->
+          case Regex.run(~r/^([£$€])/, first["price"] || "") do
+            [_, s] -> s
+            _ -> "£"
+          end
+
+        _ ->
+          "£"
+      end
+
+    "#{symbol}#{:erlang.float_to_binary(total, decimals: 2)}"
   end
 
   defp sanitize_cart_image_url(nil), do: nil
@@ -413,6 +474,7 @@ defmodule JargaAdminWeb.StorefrontLive do
       <StorefrontComponents.cart_drawer
         open={@cart_open}
         items={@cart_items}
+        subtotal={@cart_subtotal}
       />
     </div>
     """

--- a/test/jarga_admin_web/live/storefront_live_test.exs
+++ b/test/jarga_admin_web/live/storefront_live_test.exs
@@ -521,6 +521,40 @@ defmodule JargaAdminWeb.StorefrontLiveTest do
       refute has_element?(view, ".sf-cart-item-name", "Test Cart Item")
     end
 
+    test "update_cart_quantity changes item quantity", %{conn: conn, bypass: bypass} do
+      stub_storefront_api(bypass)
+
+      {:ok, view, _html} = live(conn, "/store")
+
+      render_click(view, "add_to_cart", %{
+        "id" => "prod-1",
+        "name" => "Qty Item",
+        "price" => "£10.00",
+        "image_url" => "/img/1.jpg"
+      })
+
+      # Increase quantity
+      render_click(view, "update_cart_quantity", %{"id" => "prod-1", "delta" => "1"})
+
+      # Cart count should be 2
+      assert has_element?(view, ".sf-cart-badge", "2")
+    end
+
+    test "cart shows subtotal", %{conn: conn, bypass: bypass} do
+      stub_storefront_api(bypass)
+
+      {:ok, view, _html} = live(conn, "/store")
+
+      render_click(view, "add_to_cart", %{
+        "id" => "prod-1",
+        "name" => "Test Item",
+        "price" => "£10.00",
+        "image_url" => "/img/1.jpg"
+      })
+
+      assert has_element?(view, ".sf-cart-subtotal")
+    end
+
     test "cart count updates when items are added", %{conn: conn, bypass: bypass} do
       stub_storefront_api(bypass)
 


### PR DESCRIPTION
Closes #108

- update_cart_quantity event with +/- delta
- Cart count = total quantity, computed subtotal
- Quantity row + remove button in cart drawer
- CSS for quantity controls
- 2 new tests, precommit 433/20