### PR TITLE
feat: conditional components — time, viewport, preview (#107)

### DIFF
--- a/assets/css/storefront.css
+++ b/assets/css/storefront.css
@@ -185,6 +185,29 @@
   transform-origin: left;
 }
 
+/* Responsive component wrappers */
+.sf-show-min-768 { display: block; }
+.sf-show-min-1024 { display: block; }
+.sf-show-max-767 { display: block; }
+.sf-show-max-1023 { display: block; }
+
+@media (max-width: 767px) {
+  .sf-show-min-768 { display: none !important; }
+  .sf-show-min-1024 { display: none !important; }
+}
+
+@media (min-width: 768px) {
+  .sf-show-max-767 { display: none !important; }
+}
+
+@media (max-width: 1023px) {
+  .sf-show-min-1024 { display: none !important; }
+}
+
+@media (min-width: 1024px) {
+  .sf-show-max-1023 { display: none !important; }
+}
+
 /* Video Hero */
 .sf-video-hero {
   position: relative;

--- a/lib/jarga_admin/storefront_renderer.ex
+++ b/lib/jarga_admin/storefront_renderer.ex
@@ -31,13 +31,80 @@ defmodule JargaAdmin.StorefrontRenderer do
 
   Returns an empty list for nil, missing components, or invalid input.
   """
-  def render_spec(nil), do: []
+  def render_spec(spec, opts \\ [])
 
-  def render_spec(%{"components" => components}) when is_list(components) do
-    Enum.map(components, &normalize_component/1)
+  def render_spec(nil, _opts), do: []
+
+  def render_spec(%{"components" => components}, opts) when is_list(components) do
+    preview = Keyword.get(opts, :preview, false)
+    now = DateTime.utc_now()
+
+    components
+    |> Enum.reduce([], fn raw, acc ->
+      conditions = if is_map(raw), do: raw["conditions"], else: nil
+
+      if evaluate_conditions(conditions, now, preview) do
+        comp = normalize_component(raw)
+        comp = apply_viewport_class(comp, conditions)
+        [comp | acc]
+      else
+        acc
+      end
+    end)
+    |> Enum.reverse()
   end
 
-  def render_spec(_), do: []
+  def render_spec(_, _opts), do: []
+
+  # ── Conditions evaluation ─────────────────────────────────────────────────
+
+  defp evaluate_conditions(nil, _now, _preview), do: true
+
+  defp evaluate_conditions(conditions, now, preview) when is_map(conditions) do
+    Enum.all?(conditions, fn {key, val} -> evaluate_condition(key, val, now, preview) end)
+  end
+
+  defp evaluate_conditions(_, _now, _preview), do: true
+
+  defp evaluate_condition("before", val, now, _preview) when is_binary(val) do
+    case DateTime.from_iso8601(val) do
+      {:ok, dt, _} -> DateTime.compare(now, dt) == :lt
+      _ -> true
+    end
+  end
+
+  defp evaluate_condition("after", val, now, _preview) when is_binary(val) do
+    case DateTime.from_iso8601(val) do
+      {:ok, dt, _} -> DateTime.compare(now, dt) in [:gt, :eq]
+      _ -> true
+    end
+  end
+
+  defp evaluate_condition("preview_only", true, _now, preview), do: preview == true
+
+  # Viewport conditions are handled client-side via CSS, not filtered
+  defp evaluate_condition("min_width", _val, _now, _preview), do: true
+  defp evaluate_condition("max_width", _val, _now, _preview), do: true
+
+  # Unknown conditions pass through
+  defp evaluate_condition(_key, _val, _now, _preview), do: true
+
+  defp apply_viewport_class(comp, nil), do: comp
+
+  defp apply_viewport_class(comp, conditions) when is_map(conditions) do
+    cond do
+      Map.has_key?(conditions, "min_width") ->
+        put_in(comp, [:assigns, :responsive_class], "sf-show-min-#{conditions["min_width"]}")
+
+      Map.has_key?(conditions, "max_width") ->
+        put_in(comp, [:assigns, :responsive_class], "sf-show-max-#{conditions["max_width"]}")
+
+      true ->
+        comp
+    end
+  end
+
+  defp apply_viewport_class(comp, _), do: comp
 
   @valid_layouts ~w(storefront landing storefront-sidebar minimal overlay-nav)
 

--- a/lib/jarga_admin_web/live/storefront_live.ex
+++ b/lib/jarga_admin_web/live/storefront_live.ex
@@ -459,7 +459,13 @@ defmodule JargaAdminWeb.StorefrontLive do
           </aside>
           <div class={["sf-content", @sidebar && "sf-content-with-sidebar"]}>
             <%= for comp <- @components do %>
-              <.render_component component={comp} />
+              <%= if comp.assigns[:responsive_class] do %>
+                <div class={comp.assigns.responsive_class}>
+                  <.render_component component={comp} />
+                </div>
+              <% else %>
+                <.render_component component={comp} />
+              <% end %>
             <% end %>
           </div>
         <% end %>
@@ -770,7 +776,10 @@ defmodule JargaAdminWeb.StorefrontLive do
     case page_result do
       {:ok, page} when is_map(page) ->
         content_json = parse_content_json(page["content_json"])
-        components = StorefrontRenderer.render_spec(content_json)
+
+        components =
+          StorefrontRenderer.render_spec(content_json, preview: socket.assigns.preview_mode)
+
         title = page["title"] || "Demo Store"
         meta_desc = page["meta_description"] || ""
         seo = if is_map(content_json), do: content_json["seo"] || %{}, else: %{}

--- a/test/jarga_admin/storefront_renderer_test.exs
+++ b/test/jarga_admin/storefront_renderer_test.exs
@@ -501,6 +501,93 @@ defmodule JargaAdmin.StorefrontRendererTest do
       assert toggle.type == "toggle"
     end
 
+    test "conditions: filters out component with before in the past" do
+      spec = %{
+        "components" => [
+          %{
+            "type" => "text_block",
+            "data" => %{"title" => "Expired", "content" => "Gone"},
+            "conditions" => %{"before" => "2020-01-01T00:00:00Z"}
+          },
+          %{
+            "type" => "text_block",
+            "data" => %{"title" => "Current", "content" => "Here"}
+          }
+        ]
+      }
+
+      comps = StorefrontRenderer.render_spec(spec)
+      assert length(comps) == 1
+      assert hd(comps).assigns.title == "Current"
+    end
+
+    test "conditions: keeps component with before in the future" do
+      future = DateTime.utc_now() |> DateTime.add(86400) |> DateTime.to_iso8601()
+
+      spec = %{
+        "components" => [
+          %{
+            "type" => "text_block",
+            "data" => %{"title" => "Active", "content" => "Here"},
+            "conditions" => %{"before" => future}
+          }
+        ]
+      }
+
+      comps = StorefrontRenderer.render_spec(spec)
+      assert length(comps) == 1
+    end
+
+    test "conditions: filters out component with after in the future" do
+      future = DateTime.utc_now() |> DateTime.add(86400) |> DateTime.to_iso8601()
+
+      spec = %{
+        "components" => [
+          %{
+            "type" => "text_block",
+            "data" => %{"title" => "NotYet", "content" => "Waiting"},
+            "conditions" => %{"after" => future}
+          }
+        ]
+      }
+
+      comps = StorefrontRenderer.render_spec(spec)
+      assert length(comps) == 0
+    end
+
+    test "conditions: viewport adds responsive_class to component assigns" do
+      spec = %{
+        "components" => [
+          %{
+            "type" => "text_block",
+            "data" => %{"title" => "Desktop", "content" => "Only"},
+            "conditions" => %{"min_width" => 768}
+          }
+        ]
+      }
+
+      [comp] = StorefrontRenderer.render_spec(spec)
+      assert comp.assigns.responsive_class == "sf-show-min-768"
+    end
+
+    test "conditions: preview_only filters when not in preview" do
+      spec = %{
+        "components" => [
+          %{
+            "type" => "text_block",
+            "data" => %{"title" => "Preview", "content" => "Only"},
+            "conditions" => %{"preview_only" => true}
+          }
+        ]
+      }
+
+      comps = StorefrontRenderer.render_spec(spec)
+      assert length(comps) == 0
+
+      comps_preview = StorefrontRenderer.render_spec(spec, preview: true)
+      assert length(comps_preview) == 1
+    end
+
     test "product_detail normalizes variants" do
       spec = %{
         "components" => [


### PR DESCRIPTION
Closes #107

- `conditions` on any component: `before`/`after` (time), `min_width`/`max_width` (viewport CSS), `preview_only`
- Server-side filtering for time + preview conditions
- CSS responsive wrappers for viewport conditions
- `render_spec/2` accepts `preview:` option
- 5 new tests, precommit 438/20