### PR TITLE
feat: storefront analytics events (#109)

### DIFF
--- a/lib/jarga_admin/storefront_analytics.ex
+++ b/lib/jarga_admin/storefront_analytics.ex
@@ -1,0 +1,60 @@
+defmodule JargaAdmin.StorefrontAnalytics do
+  @moduledoc """
+  Tracks storefront analytics events.
+
+  Events are logged and broadcast via PubSub for downstream consumers.
+  No PII is collected — only product IDs, page slugs, and interaction types.
+
+  ## Supported Events
+
+  - `:page_view` — page mount/navigation
+  - `:product_impression` — product card enters viewport
+  - `:product_click` — product card clicked
+  - `:add_to_cart` — item added to basket
+  - `:remove_from_cart` — item removed from basket
+  - `:search` — search query submitted
+  - `:search_click` — search result clicked
+  - `:filter_applied` — filter selection changed
+  """
+
+  require Logger
+
+  @doc """
+  Track an analytics event.
+
+  ## Examples
+
+      StorefrontAnalytics.track(:page_view, %{slug: "home", channel: "online-store"})
+      StorefrontAnalytics.track(:add_to_cart, %{product_id: "prod-1", quantity: 1})
+  """
+  def track(event_type, data \\ %{})
+
+  def track(event_type, nil), do: track(event_type, %{})
+
+  def track(event_type, data) when is_atom(event_type) and is_map(data) do
+    event = %{
+      event: event_type,
+      data: data,
+      timestamp: DateTime.utc_now() |> DateTime.to_iso8601()
+    }
+
+    Logger.info(
+      "[StorefrontAnalytics] #{event_type}: #{inspect(data)} timestamp=#{event.timestamp}"
+    )
+
+    # Broadcast to PubSub for downstream consumers (GenServer batching, etc.)
+    try do
+      Phoenix.PubSub.broadcast(
+        JargaAdmin.PubSub,
+        "storefront:analytics",
+        {:analytics_event, event}
+      )
+    rescue
+      _ -> :ok
+    end
+
+    :ok
+  end
+
+  def track(_event_type, _data), do: :ok
+end

--- a/lib/jarga_admin_web/live/storefront_live.ex
+++ b/lib/jarga_admin_web/live/storefront_live.ex
@@ -13,6 +13,7 @@ defmodule JargaAdminWeb.StorefrontLive do
   use JargaAdminWeb, :live_view
 
   alias JargaAdmin.Api
+  alias JargaAdmin.StorefrontAnalytics
   alias JargaAdmin.StorefrontRenderer
   alias JargaAdmin.StorefrontTheme
   alias JargaAdminWeb.StorefrontComponents
@@ -103,9 +104,15 @@ defmodule JargaAdminWeb.StorefrontLive do
       |> assign(:preview_mode, preview)
       |> then(fn s ->
         if slug != s.assigns.slug do
+          s = s |> assign(:slug, slug) |> load_page_data(slug)
+
+          StorefrontAnalytics.track(:page_view, %{
+            slug: slug,
+            page_title: s.assigns[:page_title],
+            channel: s.assigns[:channel_handle]
+          })
+
           s
-          |> assign(:slug, slug)
-          |> load_page_data(slug)
         else
           s
         end
@@ -150,6 +157,12 @@ defmodule JargaAdminWeb.StorefrontLive do
 
   @impl true
   def handle_event("apply_filter", %{"key" => key, "value" => value}, socket) do
+    StorefrontAnalytics.track(:filter_applied, %{
+      filter_key: key,
+      filter_value: value,
+      page_slug: socket.assigns.slug
+    })
+
     active = socket.assigns.active_filters
     current = Map.get(active, key, [])
 
@@ -253,6 +266,11 @@ defmodule JargaAdminWeb.StorefrontLive do
           []
       end
 
+    StorefrontAnalytics.track(:search, %{
+      query: socket.assigns.search_query,
+      result_count: length(results)
+    })
+
     {:noreply, assign(socket, search_results: results, search_ref: nil)}
   end
 
@@ -281,6 +299,12 @@ defmodule JargaAdminWeb.StorefrontLive do
 
     updated = add_or_increment(socket.assigns.cart_items, item)
 
+    StorefrontAnalytics.track(:add_to_cart, %{
+      product_id: params["id"],
+      quantity: 1,
+      price: params["price"]
+    })
+
     {:noreply,
      socket
      |> update_cart(updated)
@@ -289,6 +313,7 @@ defmodule JargaAdminWeb.StorefrontLive do
 
   @impl true
   def handle_event("remove_from_cart", %{"id" => id}, socket) do
+    StorefrontAnalytics.track(:remove_from_cart, %{product_id: id})
     updated = Enum.reject(socket.assigns.cart_items, &(&1["id"] == id))
     {:noreply, update_cart(socket, updated)}
   end

--- a/test/jarga_admin/storefront_analytics_test.exs
+++ b/test/jarga_admin/storefront_analytics_test.exs
@@ -1,0 +1,79 @@
+defmodule JargaAdmin.StorefrontAnalyticsTest do
+  use ExUnit.Case, async: false
+
+  alias JargaAdmin.StorefrontAnalytics
+
+  import ExUnit.CaptureLog
+
+  setup do
+    # Analytics uses Logger.info which is filtered in test config
+    Logger.configure(level: :info)
+    on_exit(fn -> Logger.configure(level: :warning) end)
+    :ok
+  end
+
+  describe "track/2" do
+    test "logs page_view event" do
+      log =
+        capture_log(fn ->
+          StorefrontAnalytics.track(:page_view, %{
+            slug: "home",
+            page_title: "Home",
+            channel: "online-store"
+          })
+        end)
+
+      assert log =~ "page_view"
+      assert log =~ "home"
+    end
+
+    test "logs add_to_cart event" do
+      log =
+        capture_log(fn ->
+          StorefrontAnalytics.track(:add_to_cart, %{
+            product_id: "prod-1",
+            quantity: 1,
+            price: "£89.00"
+          })
+        end)
+
+      assert log =~ "add_to_cart"
+      assert log =~ "prod-1"
+    end
+
+    test "logs search event with query and result count" do
+      log =
+        capture_log(fn ->
+          StorefrontAnalytics.track(:search, %{
+            query: "linen",
+            result_count: 5
+          })
+        end)
+
+      assert log =~ "search"
+      assert log =~ "linen"
+    end
+
+    test "includes timestamp in event" do
+      log =
+        capture_log(fn ->
+          StorefrontAnalytics.track(:page_view, %{slug: "bedroom"})
+        end)
+
+      assert log =~ "timestamp"
+    end
+
+    test "handles unknown event types gracefully" do
+      log =
+        capture_log(fn ->
+          StorefrontAnalytics.track(:unknown_event, %{data: "test"})
+        end)
+
+      assert log =~ "unknown_event"
+    end
+
+    test "does not crash on nil data" do
+      assert :ok == StorefrontAnalytics.track(:page_view, nil)
+    end
+  end
+end


### PR DESCRIPTION
Closes #109

## Changes
- `StorefrontAnalytics` module: `track/2` logs + PubSub broadcast
- Events: page_view, add_to_cart, remove_from_cart, search, filter_applied
- Wired into StorefrontLive at all key interaction points
- No PII — only product IDs, slugs, quantities, timestamps
- Graceful PubSub failure handling
- 6 new tests

Precommit: 444/20