### PR TITLE
fix: footer slot decode, preview conditional reload, PDP cart values (#130-#132)

### DIFF
--- a/lib/jarga_admin_web/components/storefront_components.ex
+++ b/lib/jarga_admin_web/components/storefront_components.ex
@@ -405,6 +405,9 @@ defmodule JargaAdminWeb.StorefrontComponents do
           class="sf-btn-primary sf-pdp-add"
           phx-click="add_to_cart"
           phx-value-id={@id}
+          phx-value-name={@name}
+          phx-value-price={@price}
+          phx-value-image_url={Enum.at(@images || [], 0)}
         >
           ADD TO BASKET
         </button>

--- a/lib/jarga_admin_web/live/storefront_live.ex
+++ b/lib/jarga_admin_web/live/storefront_live.ex
@@ -99,18 +99,23 @@ defmodule JargaAdminWeb.StorefrontLive do
     slug = resolve_slug(params)
     preview = params["preview"] == "true"
 
+    slug_changed = slug != socket.assigns.slug
+    preview_changed = preview != socket.assigns.preview_mode
+
     socket =
       socket
       |> assign(:preview_mode, preview)
       |> then(fn s ->
-        if slug != s.assigns.slug do
+        if slug_changed or preview_changed do
           s = s |> assign(:slug, slug) |> load_page_data(slug)
 
-          StorefrontAnalytics.track(:page_view, %{
-            slug: slug,
-            page_title: s.assigns[:page_title],
-            channel: s.assigns[:channel_handle]
-          })
+          if slug_changed do
+            StorefrontAnalytics.track(:page_view, %{
+              slug: slug,
+              page_title: s.assigns[:page_title],
+              channel: s.assigns[:channel_handle]
+            })
+          end
 
           s
         else
@@ -853,6 +858,19 @@ defmodule JargaAdminWeb.StorefrontLive do
   end
 
   defp apply_footer_data(socket, {:ok, %{"payload_json" => payload}}) when is_map(payload) do
+    apply_footer_payload(socket, payload)
+  end
+
+  defp apply_footer_data(socket, {:ok, %{"payload_json" => payload}}) when is_binary(payload) do
+    case Jason.decode(payload) do
+      {:ok, map} when is_map(map) -> apply_footer_payload(socket, map)
+      _ -> socket
+    end
+  end
+
+  defp apply_footer_data(socket, _), do: socket
+
+  defp apply_footer_payload(socket, payload) when is_map(payload) do
     columns = payload["columns"] || socket.assigns.footer_columns
     copyright = payload["copyright"] || socket.assigns.footer_copyright
 
@@ -860,8 +878,6 @@ defmodule JargaAdminWeb.StorefrontLive do
     |> assign(:footer_columns, columns)
     |> assign(:footer_copyright, copyright)
   end
-
-  defp apply_footer_data(socket, _), do: socket
 
   # content_json may be a JSON string (from the backend) or an already-decoded map (from tests)
   defp parse_content_json(json) when is_binary(json) do


### PR DESCRIPTION
Closes #130 #131 #132

Found via API-driven Playwright E2E testing (9 tests driving real API calls + verifying rendering).

**#130 Footer slot**: `payload_json` is returned as a JSON string from the API, but `apply_footer_data` only matched maps. Added string decoding clause.

**#131 Preview conditional**: `preview_mode` was always `false` during `mount` → `load_page_data`. Components with `conditions: {preview_only: true}` were always filtered out. Fixed by re-rendering spec in `handle_params` when preview mode changes.

**#132 PDP cart**: ADD TO BASKET button was missing `phx-value-name`, `phx-value-price`, `phx-value-image_url`. Cart drawer showed 'Product' with £0.00.