### PR TITLE
fix: cart subtotal Unicode regex crashes LiveView (#134)

### DIFF
--- a/lib/jarga_admin_web/live/storefront_live.ex
+++ b/lib/jarga_admin_web/live/storefront_live.ex
@@ -381,7 +381,7 @@ defmodule JargaAdminWeb.StorefrontLive do
     symbol =
       case items do
         [first | _] ->
-          case Regex.run(~r/^([£$€])/, first["price"] || "") do
+          case Regex.run(~r/^([£$€])/u, first["price"] || "") do
             [_, s] -> s
             _ -> "£"
           end


### PR DESCRIPTION
Closes #134

**Root cause**: `~r/^([£$€])/` without `u` flag captures byte 0xC2 instead of full £ character (0xC2A3). This produces invalid UTF-8 that crashes Jason serialization, killing the LiveView.

Found via API-driven Playwright E2E testing — adding a £89.00 product to cart from PDP.

**Fix**: `~r/^([£$€])/u` (add Unicode flag)