### PR TITLE
fix: resolve 60 test failures — missing tab position key & keyboard shortcut handlers

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -222,6 +222,62 @@ Hooks.Chart = {
 }
 
 /**
+ * KeyboardShortcuts — global keyboard shortcuts for navigation and actions.
+ * Pushes server events: navigate_to, keyboard_refresh, keyboard_escape,
+ * keyboard_new, toggle_shortcuts_modal.
+ */
+Hooks.KeyboardShortcuts = {
+  mounted() {
+    this._gPressed = false
+    this._gTimer = null
+
+    this._handler = (e) => {
+      // Ignore when typing in inputs/textareas
+      const tag = e.target.tagName
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || e.target.isContentEditable) return
+
+      // "G then X" navigation combos
+      if (this._gPressed) {
+        this._gPressed = false
+        clearTimeout(this._gTimer)
+        const map = { o: "orders", p: "products", c: "customers", a: "analytics", i: "inventory", s: "shipping", m: "promotions" }
+        const tab = map[e.key.toLowerCase()]
+        if (tab) {
+          e.preventDefault()
+          this.pushEvent("navigate_to", { tab })
+        }
+        return
+      }
+
+      if (e.key === "g") {
+        this._gPressed = true
+        this._gTimer = setTimeout(() => { this._gPressed = false }, 500)
+        return
+      }
+
+      if (e.key === "?" || (e.key === "/" && e.shiftKey)) {
+        e.preventDefault()
+        this.pushEvent("toggle_shortcuts_modal", {})
+      } else if (e.key === "Escape") {
+        this.pushEvent("keyboard_escape", {})
+      } else if (e.key === "r" && !e.ctrlKey && !e.metaKey) {
+        e.preventDefault()
+        this.pushEvent("keyboard_refresh", {})
+      } else if (e.key === "n" && !e.ctrlKey && !e.metaKey) {
+        e.preventDefault()
+        this.pushEvent("keyboard_new", {})
+      }
+    }
+
+    window.addEventListener("keydown", this._handler)
+  },
+  destroyed() {
+    window.removeEventListener("keydown", this._handler)
+    clearTimeout(this._gTimer)
+  }
+}
+
+/**
  * ContextMenu — show/hide tab context menu at cursor position.
  */
 Hooks.ContextMenu = {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -259,7 +259,12 @@ Hooks.KeyboardShortcuts = {
         e.preventDefault()
         this.pushEvent("toggle_shortcuts_modal", {})
       } else if (e.key === "Escape") {
-        this.pushEvent("keyboard_escape", {})
+        // Only push if a modal, chat, or detail panel might be open
+        const hasModal = document.getElementById("keyboard-shortcuts-modal")
+        const chatOpen = document.querySelector(".j-chat-popover.open")
+        if (hasModal || chatOpen) {
+          this.pushEvent("keyboard_escape", {})
+        }
       } else if (e.key === "r" && !e.ctrlKey && !e.metaKey) {
         e.preventDefault()
         this.pushEvent("keyboard_refresh", {})

--- a/lib/jarga_admin/tab_store.ex
+++ b/lib/jarga_admin/tab_store.ex
@@ -329,7 +329,7 @@ defmodule JargaAdmin.TabStore do
     @table
     |> :ets.tab2list()
     |> Enum.map(fn {_id, tab} -> tab end)
-    |> Enum.sort_by(& &1.position)
+    |> Enum.sort_by(fn tab -> Map.get(tab, :position, 999) end)
   end
 
   @doc "Get a tab by id."

--- a/lib/jarga_admin/tab_store.ex
+++ b/lib/jarga_admin/tab_store.ex
@@ -342,9 +342,20 @@ defmodule JargaAdmin.TabStore do
 
   @doc "Insert or replace a tab."
   def put(tab) do
-    tab = Map.put_new(tab, :id, generate_id())
+    tab =
+      tab
+      |> Map.put_new(:id, generate_id())
+      |> Map.put_new(:position, next_position())
+
     :ets.insert(@table, {tab.id, tab})
     tab
+  end
+
+  defp next_position do
+    case list() do
+      [] -> 0
+      tabs -> tabs |> Enum.map(& &1.position) |> Enum.max() |> Kernel.+(1)
+    end
   end
 
   @doc "Pin a new view as a tab."

--- a/lib/jarga_admin_web/live/chat_live.ex
+++ b/lib/jarga_admin_web/live/chat_live.ex
@@ -23,6 +23,7 @@ defmodule JargaAdminWeb.ChatLive do
 
   @session_id "main"
   @pubsub JargaAdmin.PubSub
+  @creatable_tabs ~w(products customers orders promotions shipping)
 
   # ──────────────────────────────────────────────────────────────────────────
   # Mount
@@ -159,7 +160,6 @@ defmodule JargaAdminWeb.ChatLive do
       <div
         id="keyboard-shortcuts-modal"
         class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-        phx-click="close_shortcuts_modal"
       >
         <div
           class="bg-white rounded-lg shadow-xl max-w-md w-full p-6"
@@ -179,6 +179,8 @@ defmodule JargaAdminWeb.ChatLive do
             <div class="flex justify-between"><span>Customers</span><kbd class="text-xs bg-gray-100 px-1.5 py-0.5 rounded">G then C</kbd></div>
             <div class="flex justify-between"><span>Analytics</span><kbd class="text-xs bg-gray-100 px-1.5 py-0.5 rounded">G then A</kbd></div>
             <div class="flex justify-between"><span>Inventory</span><kbd class="text-xs bg-gray-100 px-1.5 py-0.5 rounded">G then I</kbd></div>
+            <div class="flex justify-between"><span>Shipping</span><kbd class="text-xs bg-gray-100 px-1.5 py-0.5 rounded">G then S</kbd></div>
+            <div class="flex justify-between"><span>Promotions</span><kbd class="text-xs bg-gray-100 px-1.5 py-0.5 rounded">G then M</kbd></div>
 
             <h3 class="font-medium text-gray-500 uppercase text-xs tracking-wide mt-4">Actions</h3>
             <div class="flex justify-between"><span>Refresh</span><kbd class="text-xs bg-gray-100 px-1.5 py-0.5 rounded">R</kbd></div>
@@ -2616,23 +2618,49 @@ defmodule JargaAdminWeb.ChatLive do
 
   @impl true
   def handle_event("navigate_to", %{"tab" => tab_id}, socket) do
-    tabs = TabStore.list()
-
-    if Enum.any?(tabs, &(&1.id == tab_id)) do
-      spec = TabStore.get_or_build_spec(tab_id)
-
-      socket =
-        socket
-        |> assign(:active_tab_id, tab_id)
-        |> assign(:tabs, tabs)
-        |> assign(:detail, nil)
-        |> assign(:rendered_components, Renderer.render_spec(spec))
-
-      route = tab_id_to_route(tab_id)
-      socket = if route, do: push_patch(socket, to: route), else: socket
+    # No-op if already on target tab
+    if tab_id == socket.assigns.active_tab_id do
       {:noreply, socket}
     else
-      {:noreply, socket}
+      tabs = TabStore.list()
+
+      if Enum.any?(tabs, &(&1.id == tab_id)) do
+        tab = find_tab(tabs, tab_id)
+
+        # Use async pattern matching switch_tab for uncached specs
+        cached_spec =
+          case TabStore.get(tab_id) do
+            {:ok, %{ui_spec: spec}} when not is_nil(spec) -> spec
+            _ -> nil
+          end
+
+        socket =
+          socket
+          |> assign(:active_tab_id, tab_id)
+          |> assign(:tabs, tabs)
+          |> assign(:detail, nil)
+
+        socket =
+          if cached_spec do
+            assign(socket, :rendered_components, Renderer.render_spec(cached_spec))
+          else
+            Task.async(fn -> {tab_id, TabStore.get_or_build_spec(tab_id)} end)
+
+            socket
+            |> assign(:rendered_components, [])
+            |> update(:loading_tabs, &MapSet.put(&1, tab_id))
+          end
+
+        if tab && tab.refresh_interval != :off do
+          schedule_tab_refresh(tab_id, tab.refresh_interval)
+        end
+
+        route = tab_id_to_route(tab_id)
+        socket = if route, do: push_patch(socket, to: route), else: socket
+        {:noreply, socket}
+      else
+        {:noreply, socket}
+      end
     end
   end
 
@@ -2675,9 +2703,7 @@ defmodule JargaAdminWeb.ChatLive do
   def handle_event("keyboard_new", _, socket) do
     tab_id = socket.assigns.active_tab_id
 
-    creatable_tabs = ~w(products customers orders promotions shipping)
-
-    if tab_id in creatable_tabs do
+    if tab_id in @creatable_tabs do
       {:noreply, assign(socket, :detail, %{type: :create_form, resource: tab_id})}
     else
       {:noreply, socket}

--- a/lib/jarga_admin_web/live/chat_live.ex
+++ b/lib/jarga_admin_web/live/chat_live.ex
@@ -80,6 +80,8 @@ defmodule JargaAdminWeb.ChatLive do
       |> assign(:last_refreshed, %{})
       # Bulk selection — MapSet of selected item IDs
       |> assign(:selected_ids, MapSet.new())
+      # Keyboard shortcuts modal — boolean toggle
+      |> assign(:shortcuts_modal, false)
 
     {:ok, socket}
   end
@@ -149,6 +151,45 @@ defmodule JargaAdminWeb.ChatLive do
   @impl true
   def render(assigns) do
     ~H"""
+    <%!-- Keyboard shortcuts listener --%>
+    <div id="keyboard-shortcuts-hook" phx-hook="KeyboardShortcuts" class="hidden"></div>
+
+    <%!-- Keyboard shortcuts modal --%>
+    <%= if @shortcuts_modal do %>
+      <div
+        id="keyboard-shortcuts-modal"
+        class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+        phx-click="close_shortcuts_modal"
+      >
+        <div
+          class="bg-white rounded-lg shadow-xl max-w-md w-full p-6"
+          phx-click-away="close_shortcuts_modal"
+        >
+          <div class="flex items-center justify-between mb-4">
+            <h2 class="text-lg font-semibold">Keyboard shortcuts</h2>
+            <button phx-click="close_shortcuts_modal" class="text-gray-400 hover:text-gray-600">
+              <.icon name="hero-x-mark" class="w-5 h-5" />
+            </button>
+          </div>
+
+          <div class="space-y-3 text-sm">
+            <h3 class="font-medium text-gray-500 uppercase text-xs tracking-wide">Navigation</h3>
+            <div class="flex justify-between"><span>Orders</span><kbd class="text-xs bg-gray-100 px-1.5 py-0.5 rounded">G then O</kbd></div>
+            <div class="flex justify-between"><span>Products</span><kbd class="text-xs bg-gray-100 px-1.5 py-0.5 rounded">G then P</kbd></div>
+            <div class="flex justify-between"><span>Customers</span><kbd class="text-xs bg-gray-100 px-1.5 py-0.5 rounded">G then C</kbd></div>
+            <div class="flex justify-between"><span>Analytics</span><kbd class="text-xs bg-gray-100 px-1.5 py-0.5 rounded">G then A</kbd></div>
+            <div class="flex justify-between"><span>Inventory</span><kbd class="text-xs bg-gray-100 px-1.5 py-0.5 rounded">G then I</kbd></div>
+
+            <h3 class="font-medium text-gray-500 uppercase text-xs tracking-wide mt-4">Actions</h3>
+            <div class="flex justify-between"><span>Refresh</span><kbd class="text-xs bg-gray-100 px-1.5 py-0.5 rounded">R</kbd></div>
+            <div class="flex justify-between"><span>New item</span><kbd class="text-xs bg-gray-100 px-1.5 py-0.5 rounded">N</kbd></div>
+            <div class="flex justify-between"><span>Close / Escape</span><kbd class="text-xs bg-gray-100 px-1.5 py-0.5 rounded">Esc</kbd></div>
+            <div class="flex justify-between"><span>Show shortcuts</span><kbd class="text-xs bg-gray-100 px-1.5 py-0.5 rounded">?</kbd></div>
+          </div>
+        </div>
+      </div>
+    <% end %>
+
     <%!-- Toast notification stack --%>
     <JargaAdminWeb.JargaComponents.toast_container toasts={@toasts} />
 
@@ -2569,6 +2610,78 @@ defmodule JargaAdminWeb.ChatLive do
       end
 
     {:noreply, socket}
+  end
+
+  # ── Keyboard shortcuts ──────────────────────────────────────────────────
+
+  @impl true
+  def handle_event("navigate_to", %{"tab" => tab_id}, socket) do
+    tabs = TabStore.list()
+
+    if Enum.any?(tabs, &(&1.id == tab_id)) do
+      spec = TabStore.get_or_build_spec(tab_id)
+
+      socket =
+        socket
+        |> assign(:active_tab_id, tab_id)
+        |> assign(:tabs, tabs)
+        |> assign(:detail, nil)
+        |> assign(:rendered_components, Renderer.render_spec(spec))
+
+      route = tab_id_to_route(tab_id)
+      socket = if route, do: push_patch(socket, to: route), else: socket
+      {:noreply, socket}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_event("toggle_shortcuts_modal", _, socket) do
+    {:noreply, assign(socket, :shortcuts_modal, !socket.assigns.shortcuts_modal)}
+  end
+
+  @impl true
+  def handle_event("close_shortcuts_modal", _, socket) do
+    {:noreply, assign(socket, :shortcuts_modal, false)}
+  end
+
+  @impl true
+  def handle_event("keyboard_escape", _, socket) do
+    socket =
+      cond do
+        socket.assigns.shortcuts_modal ->
+          assign(socket, :shortcuts_modal, false)
+
+        socket.assigns.chat_open ->
+          assign(socket, :chat_open, false)
+
+        socket.assigns.detail != nil ->
+          assign(socket, :detail, nil)
+
+        true ->
+          socket
+      end
+
+    {:noreply, socket}
+  end
+
+  @impl true
+  def handle_event("keyboard_refresh", _, socket) do
+    {:noreply, reload_tab_spec(socket)}
+  end
+
+  @impl true
+  def handle_event("keyboard_new", _, socket) do
+    tab_id = socket.assigns.active_tab_id
+
+    creatable_tabs = ~w(products customers orders promotions shipping)
+
+    if tab_id in creatable_tabs do
+      {:noreply, assign(socket, :detail, %{type: :create_form, resource: tab_id})}
+    else
+      {:noreply, socket}
+    end
   end
 
   # ── Clear detail panel ────────────────────────────────────────────────────

--- a/test/jarga_admin/tab_store_test.exs
+++ b/test/jarga_admin/tab_store_test.exs
@@ -46,9 +46,12 @@ defmodule JargaAdmin.TabStoreTest do
   end
 
   test "unpin/1 refuses to unpin non-pinnable tabs" do
-    # Insert a synthetic non-pinnable tab directly
-    :ets.insert(:jarga_tabs, {"fixed", %{id: "fixed", label: "Fixed", pinnable: false}})
+    # Insert a synthetic non-pinnable tab directly (include position to avoid sort errors)
+    :ets.insert(:jarga_tabs, {"fixed", %{id: "fixed", label: "Fixed", pinnable: false, position: 999}})
     assert {:error, :not_pinnable} = TabStore.unpin("fixed")
+
+    # Cleanup — prevent leaking into other tests
+    :ets.delete(:jarga_tabs, "fixed")
   end
 
   test "rename/2 updates tab label" do


### PR DESCRIPTION
## Summary

Fixes **60 test failures** on `master` after the latest merge (storefront hydrator updates).

### Root causes

1. **`TabStore.list/0` KeyError** (40 failures) — A synthetic tab entry without a `:position` key was inserted in `tab_store_test.exs` and leaked into other tests via ETS. `Enum.sort_by(& &1.position)` crashed.

2. **Missing `handle_event` clauses** (20 failures) — `KeyboardShortcutsTest` expected `navigate_to`, `toggle_shortcuts_modal`, `close_shortcuts_modal`, `keyboard_escape`, `keyboard_refresh`, and `keyboard_new` events that were never implemented.

### Changes

- **`lib/jarga_admin/tab_store.ex`** — `list/0` uses `Map.get(tab, :position, 999)` for resilience
- **`test/jarga_admin/tab_store_test.exs`** — Added `:position` to synthetic tab + cleanup
- **`lib/jarga_admin_web/live/chat_live.ex`** — Added `:shortcuts_modal` assign, 6 new `handle_event` clauses, keyboard shortcuts modal template, `KeyboardShortcuts` hook div
- **`assets/js/app.js`** — Added `KeyboardShortcuts` hook (G+X navigation, ?, Esc, R, N)

### Result

```
505 tests, 0 failures (6 excluded)
```